### PR TITLE
chore: remove commitlint hook from lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,8 +2,3 @@ pre-commit:
   jobs:
     - name: lint
       run: npm run lint
-
-commit-msg:
-  jobs:
-    - name: commitlint
-      run: npx commitlint --edit {1}


### PR DESCRIPTION
## Summary
- Removes the commit-msg hook that runs commitlint on commit messages
- Commit title enforcement will be done pre-merge after squashing

## Test plan
- [x] Verify lefthook still runs lint on pre-commit