### PR TITLE
chore(renovate): use JSON instead of JSON5

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,7 +20,5 @@
       "schedule": ["before 8am on Monday"]
     }
   ],
-  "labels": [
-    "dependencies"
-  ]
+  "labels": ["dependencies"]
 }


### PR DESCRIPTION
## Summary
- Renames `renovate.json5` to `renovate.json` (standard JSON format)
- Allows biome lint to run on renovate config

No functional changes - identical configuration content.