### PR TITLE
chore: add prepare and clean scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "prepare": "lefthook install -f",
+    "clean": "npx -y rimraf -g \"**/.turbo\" \"**/dist\" \"**/node_modules\"",
     "build": "turbo run build",
     "check-types": "turbo run check-types",
     "lint": "biome format --write .",


### PR DESCRIPTION
## Summary
- Add `prepare` script to auto-install lefthook git hooks on `npm install`
- Add `clean` helper for contributors to remove `.turbo`, `dist`, and `node_modules` directories