### PR TITLE
chore(deps): update tsdown to 0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,12 +31,13 @@
         "jsdom": "27.2.0",
         "lefthook": "2.0.4",
         "publint": "0.3.15",
-        "tsdown": "0.16.4",
+        "tsdown": "0.17.0",
         "turbo": "2.6.1",
         "vitest": "4.0.14"
       },
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=22.12.0",
+        "npm": "11.6.0"
       },
       "peerDependencies": {
         "typescript": "5.9.3"
@@ -1443,9 +1444,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.97.0.tgz",
-      "integrity": "sha512-lxmZK4xFrdvU0yZiDwgVQTCvh2gHWBJCBk5ALsrtsBWhs0uDIi+FTOnXRQeQfs304imdvTdaakT/lqwQ8hkOXQ==",
+      "version": "0.101.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.101.0.tgz",
+      "integrity": "sha512-nuFhqlUzJX+gVIPPfuE6xurd4lST3mdcWOhyK/rZO0B9XWMKm79SuszIQEnSMmmDhq1DC8WWVYGVd+6F93o1gQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1503,9 +1504,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.50.tgz",
-      "integrity": "sha512-XlEkrOIHLyGT3avOgzfTFSjG+f+dZMw+/qd+Y3HLN86wlndrB/gSimrJCk4gOhr1XtRtEKfszpadI3Md4Z4/Ag==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.53.tgz",
+      "integrity": "sha512-Ok9V8o7o6YfSdTTYA/uHH30r3YtOxLD6G3wih/U9DO0ucBBFq8WPt/DslU53OgfteLRHITZny9N/qCUxMf9kjQ==",
       "cpu": [
         "arm64"
       ],
@@ -1520,9 +1521,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.50.tgz",
-      "integrity": "sha512-+JRqKJhoFlt5r9q+DecAGPLZ5PxeLva+wCMtAuoFMWPoZzgcYrr599KQ+Ix0jwll4B4HGP43avu9My8KtSOR+w==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.53.tgz",
+      "integrity": "sha512-yIsKqMz0CtRnVa6x3Pa+mzTihr4Ty+Z6HfPbZ7RVbk1Uxnco4+CUn7Qbm/5SBol1JD/7nvY8rphAgyAi7Lj6Vg==",
       "cpu": [
         "arm64"
       ],
@@ -1537,9 +1538,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.50.tgz",
-      "integrity": "sha512-fFXDjXnuX7/gQZQm/1FoivVtRcyAzdjSik7Eo+9iwPQ9EgtA5/nB2+jmbzaKtMGG3q+BnZbdKHCtOacmNrkIDA==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.53.tgz",
+      "integrity": "sha512-GTXe+mxsCGUnJOFMhfGWmefP7Q9TpYUseHvhAhr21nCTgdS8jPsvirb0tJwM3lN0/u/cg7bpFNa16fQrjKrCjQ==",
       "cpu": [
         "x64"
       ],
@@ -1554,9 +1555,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.50.tgz",
-      "integrity": "sha512-F1b6vARy49tjmT/hbloplzgJS7GIvwWZqt+tAHEstCh0JIh9sa8FAMVqEmYxDviqKBaAI8iVvUREm/Kh/PD26Q==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.53.tgz",
+      "integrity": "sha512-9Tmp7bBvKqyDkMcL4e089pH3RsjD3SUungjmqWtyhNOxoQMh0fSmINTyYV8KXtE+JkxYMPWvnEt+/mfpVCkk8w==",
       "cpu": [
         "x64"
       ],
@@ -1571,9 +1572,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.50.tgz",
-      "integrity": "sha512-U6cR76N8T8M6lHj7EZrQ3xunLPxSvYYxA8vJsBKZiFZkT8YV4kjgCO3KwMJL0NOjQCPGKyiXO07U+KmJzdPGRw==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.53.tgz",
+      "integrity": "sha512-a1y5fiB0iovuzdbjUxa7+Zcvgv+mTmlGGC4XydVIsyl48eoxgaYkA3l9079hyTyhECsPq+mbr0gVQsFU11OJAQ==",
       "cpu": [
         "arm"
       ],
@@ -1588,9 +1589,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.50.tgz",
-      "integrity": "sha512-ONgyjofCrrE3bnh5GZb8EINSFyR/hmwTzZ7oVuyUB170lboza1VMCnb8jgE6MsyyRgHYmN8Lb59i3NKGrxrYjw==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.53.tgz",
+      "integrity": "sha512-bpIGX+ov9PhJYV+wHNXl9rzq4F0QvILiURn0y0oepbQx+7stmQsKA0DhPGwmhfvF856wq+gbM8L92SAa/CBcLg==",
       "cpu": [
         "arm64"
       ],
@@ -1605,9 +1606,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.50.tgz",
-      "integrity": "sha512-L0zRdH2oDPkmB+wvuTl+dJbXCsx62SkqcEqdM+79LOcB+PxbAxxjzHU14BuZIQdXcAVDzfpMfaHWzZuwhhBTcw==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.53.tgz",
+      "integrity": "sha512-bGe5EBB8FVjHBR1mOLOPEFg1Lp3//7geqWkU5NIhxe+yH0W8FVrQ6WRYOap4SUTKdklD/dC4qPLREkMMQ855FA==",
       "cpu": [
         "arm64"
       ],
@@ -1622,9 +1623,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.50.tgz",
-      "integrity": "sha512-gyoI8o/TGpQd3OzkJnh1M2kxy1Bisg8qJ5Gci0sXm9yLFzEXIFdtc4EAzepxGvrT2ri99ar5rdsmNG0zP0SbIg==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.53.tgz",
+      "integrity": "sha512-qL+63WKVQs1CMvFedlPt0U9PiEKJOAL/bsHMKUDS6Vp2Q+YAv/QLPu8rcvkfIMvQ0FPU2WL0aX4eWwF6e/GAnA==",
       "cpu": [
         "x64"
       ],
@@ -1639,9 +1640,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.50.tgz",
-      "integrity": "sha512-zti8A7M+xFDpKlghpcCAzyOi+e5nfUl3QhU023ce5NCgUxRG5zGP2GR9LTydQ1rnIPwZUVBWd4o7NjZDaQxaXA==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.53.tgz",
+      "integrity": "sha512-VGl9JIGjoJh3H8Mb+7xnVqODajBmrdOOb9lxWXdcmxyI+zjB2sux69br0hZJDTyLJfvBoYm439zPACYbCjGRmw==",
       "cpu": [
         "x64"
       ],
@@ -1656,9 +1657,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.50.tgz",
-      "integrity": "sha512-eZUssog7qljrrRU9Mi0eqYEPm3Ch0UwB+qlWPMKSUXHNqhm3TvDZarJQdTevGEfu3EHAXJvBIe0YFYr0TPVaMA==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.53.tgz",
+      "integrity": "sha512-B4iIserJXuSnNzA5xBLFUIjTfhNy7d9sq4FUMQY3GhQWGVhS2RWWzzDnkSU6MUt7/aHUrep0CdQfXUJI9D3W7A==",
       "cpu": [
         "arm64"
       ],
@@ -1673,9 +1674,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.50.tgz",
-      "integrity": "sha512-nmCN0nIdeUnmgeDXiQ+2HU6FT162o+rxnF7WMkBm4M5Ds8qTU7Dzv2Wrf22bo4ftnlrb2hKK6FSwAJSAe2FWLg==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.53.tgz",
+      "integrity": "sha512-BUjAEgpABEJXilGq/BPh7jeU3WAJ5o15c1ZEgHaDWSz3LB881LQZnbNJHmUiM4d1JQWMYYyR1Y490IBHi2FPJg==",
       "cpu": [
         "wasm32"
       ],
@@ -1683,16 +1684,16 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.0.7"
+        "@napi-rs/wasm-runtime": "^1.1.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.50.tgz",
-      "integrity": "sha512-7kcNLi7Ua59JTTLvbe1dYb028QEPaJPJQHqkmSZ5q3tJueUeb6yjRtx8mw4uIqgWZcnQHAR3PrLN4XRJxvgIkA==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.53.tgz",
+      "integrity": "sha512-s27uU7tpCWSjHBnxyVXHt3rMrQdJq5MHNv3BzsewCIroIw3DJFjMH1dzCPPMUFxnh1r52Nf9IJ/eWp6LDoyGcw==",
       "cpu": [
         "arm64"
       ],
@@ -1706,27 +1707,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-win32-ia32-msvc": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.0.0-beta.50.tgz",
-      "integrity": "sha512-lL70VTNvSCdSZkDPPVMwWn/M2yQiYvSoXw9hTLgdIWdUfC3g72UaruezusR6ceRuwHCY1Ayu2LtKqXkBO5LIwg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.50.tgz",
-      "integrity": "sha512-4qU4x5DXWB4JPjyTne/wBNPqkbQU8J45bl21geERBKtEittleonioACBL1R0PsBu0Aq21SwMK5a9zdBkWSlQtQ==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.53.tgz",
+      "integrity": "sha512-cjWL/USPJ1g0en2htb4ssMjIycc36RvdQAx1WlXnS6DpULswiUTVXPDesTifSKYSyvx24E0YqQkEm0K/M2Z/AA==",
       "cpu": [
         "x64"
       ],
@@ -1741,9 +1725,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.50.tgz",
-      "integrity": "sha512-5e76wQiQVeL1ICOZVUg4LSOVYg9jyhGCin+icYozhsUzM+fHE7kddi1bdiE0jwVqTfkjba3jUFbEkoC9WkdvyA==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
+      "integrity": "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2475,9 +2459,9 @@
       }
     },
     "node_modules/birpc": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
-      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-3.0.0.tgz",
+      "integrity": "sha512-by+04pHuxpCEQcucAXqzopqfhyI8TLK5Qg5MST0cB6MP+JhHna9ollrtK9moVh27aq6Q6MEJgebD0cVm//yBkg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2525,22 +2509,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -2764,16 +2732,6 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/diff": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
-      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -3203,6 +3161,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/import-without-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/import-without-cache/-/import-without-cache-0.2.2.tgz",
+      "integrity": "sha512-4TTuRrZ0jBULXzac3EoX9ZviOs8Wn9iAbNhJEyLhTpAGF9eNmYSruaMMN/Tec/yqaO7H6yS2kALfQDJ5FxfatA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
       }
     },
     "node_modules/ini": {
@@ -4098,20 +4069,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4166,14 +4123,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-beta.50",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.50.tgz",
-      "integrity": "sha512-JFULvCNl/anKn99eKjOSEubi0lLmNqQDAjyEMME2T4CwezUDL0i6t1O9xZsu2OMehPnV2caNefWpGF+8TnzB6A==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.53.tgz",
+      "integrity": "sha512-Qd9c2p0XKZdgT5AYd+KgAMggJ8ZmCs3JnS9PTMWkyUfteKlfmKtxJbWTHkVakxwXs1Ub7jrRYVeFeF7N0sQxyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.97.0",
-        "@rolldown/pluginutils": "1.0.0-beta.50"
+        "@oxc-project/types": "=0.101.0",
+        "@rolldown/pluginutils": "1.0.0-beta.53"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -4182,26 +4139,25 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-beta.50",
-        "@rolldown/binding-darwin-arm64": "1.0.0-beta.50",
-        "@rolldown/binding-darwin-x64": "1.0.0-beta.50",
-        "@rolldown/binding-freebsd-x64": "1.0.0-beta.50",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-beta.50",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-beta.50",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-beta.50",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.50",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-beta.50",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-beta.50",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-beta.50",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-beta.50",
-        "@rolldown/binding-win32-ia32-msvc": "1.0.0-beta.50",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-beta.50"
+        "@rolldown/binding-android-arm64": "1.0.0-beta.53",
+        "@rolldown/binding-darwin-arm64": "1.0.0-beta.53",
+        "@rolldown/binding-darwin-x64": "1.0.0-beta.53",
+        "@rolldown/binding-freebsd-x64": "1.0.0-beta.53",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-beta.53",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-beta.53",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-beta.53",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.53",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-beta.53",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-beta.53",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-beta.53",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-beta.53",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-beta.53"
       }
     },
     "node_modules/rolldown-plugin-dts": {
-      "version": "0.17.8",
-      "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.17.8.tgz",
-      "integrity": "sha512-76EEBlhF00yeY6M7VpMkWKI4r9WjuoMiOGey7j4D6zf3m0BR+ZrrY9hvSXdueJ3ljxSLq4DJBKFpX/X9+L7EKw==",
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.18.3.tgz",
+      "integrity": "sha512-rd1LZ0Awwfyn89UndUF/HoFF4oH9a5j+2ZeuKSJYM80vmeN/p0gslYMnHTQHBEXPhUlvAlqGA3tVgXB/1qFNDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4209,11 +4165,11 @@
         "@babel/parser": "^7.28.5",
         "@babel/types": "^7.28.5",
         "ast-kit": "^2.2.0",
-        "birpc": "^2.8.0",
+        "birpc": "^3.0.0",
         "dts-resolver": "^2.1.3",
         "get-tsconfig": "^4.13.0",
         "magic-string": "^0.30.21",
-        "obug": "^2.0.0"
+        "obug": "^2.1.1"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -4224,7 +4180,7 @@
       "peerDependencies": {
         "@ts-macro/tsc": "^0.3.6",
         "@typescript/native-preview": ">=7.0.0-dev.20250601.1",
-        "rolldown": "^1.0.0-beta.44",
+        "rolldown": "^1.0.0-beta.51",
         "typescript": "^5.0.0",
         "vue-tsc": "~3.1.0"
       },
@@ -4566,27 +4522,26 @@
       }
     },
     "node_modules/tsdown": {
-      "version": "0.16.4",
-      "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.16.4.tgz",
-      "integrity": "sha512-tdhy+EQpZSVrVkDRnjKEKVfh1git2HrliGp3SylRNg7kk+lOx3SvT7NLakKX5grPAg8WrZrXWLPUrCegWupqgg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.17.0.tgz",
+      "integrity": "sha512-NPZRrlC51X9Bb55ZTDwrWges8Dm1niCvNA5AYw7aix6pfnDnB4WR0neG5RPq75xIodg3hqlQUzzyrX7n4dmnJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansis": "^4.2.0",
         "cac": "^6.7.14",
-        "chokidar": "^4.0.3",
-        "diff": "^8.0.2",
         "empathic": "^2.0.0",
         "hookable": "^5.5.3",
-        "obug": "^1.0.0",
-        "rolldown": "1.0.0-beta.50",
-        "rolldown-plugin-dts": "^0.17.7",
+        "import-without-cache": "^0.2.2",
+        "obug": "^2.1.1",
+        "rolldown": "1.0.0-beta.53",
+        "rolldown-plugin-dts": "^0.18.2",
         "semver": "^7.7.3",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
         "tree-kill": "^1.2.2",
         "unconfig-core": "^7.4.1",
-        "unrun": "^0.2.9"
+        "unrun": "^0.2.16"
       },
       "bin": {
         "tsdown": "dist/run.mjs"
@@ -4599,7 +4554,7 @@
       },
       "peerDependencies": {
         "@arethetypeswrong/core": "^0.18.1",
-        "@vitejs/devtools": "^0.0.0-alpha.17",
+        "@vitejs/devtools": "^0.0.0-alpha.18",
         "publint": "^0.3.0",
         "typescript": "^5.0.0",
         "unplugin-lightningcss": "^0.4.0",
@@ -4622,25 +4577,6 @@
           "optional": true
         },
         "unplugin-unused": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tsdown/node_modules/obug": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-1.0.2.tgz",
-      "integrity": "sha512-Q3KPMFHLmJ4KENpj3HNkzU7nngmrgXrr7h19DHx/8+hNAD2St6zzb8Mamfj3VzrVTbjnIyu94WwPBO5yAB+kCQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/sxzz",
-        "https://opencollective.com/debug"
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "ms": "^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ms": {
           "optional": true
         }
       }
@@ -4829,276 +4765,6 @@
         "synckit": {
           "optional": true
         }
-      }
-    },
-    "node_modules/unrun/node_modules/@oxc-project/types": {
-      "version": "0.101.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.101.0.tgz",
-      "integrity": "sha512-nuFhqlUzJX+gVIPPfuE6xurd4lST3mdcWOhyK/rZO0B9XWMKm79SuszIQEnSMmmDhq1DC8WWVYGVd+6F93o1gQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/unrun/node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.53.tgz",
-      "integrity": "sha512-Ok9V8o7o6YfSdTTYA/uHH30r3YtOxLD6G3wih/U9DO0ucBBFq8WPt/DslU53OgfteLRHITZny9N/qCUxMf9kjQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/unrun/node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.53.tgz",
-      "integrity": "sha512-yIsKqMz0CtRnVa6x3Pa+mzTihr4Ty+Z6HfPbZ7RVbk1Uxnco4+CUn7Qbm/5SBol1JD/7nvY8rphAgyAi7Lj6Vg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/unrun/node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.53.tgz",
-      "integrity": "sha512-GTXe+mxsCGUnJOFMhfGWmefP7Q9TpYUseHvhAhr21nCTgdS8jPsvirb0tJwM3lN0/u/cg7bpFNa16fQrjKrCjQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/unrun/node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.53.tgz",
-      "integrity": "sha512-9Tmp7bBvKqyDkMcL4e089pH3RsjD3SUungjmqWtyhNOxoQMh0fSmINTyYV8KXtE+JkxYMPWvnEt+/mfpVCkk8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/unrun/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.53.tgz",
-      "integrity": "sha512-a1y5fiB0iovuzdbjUxa7+Zcvgv+mTmlGGC4XydVIsyl48eoxgaYkA3l9079hyTyhECsPq+mbr0gVQsFU11OJAQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/unrun/node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.53.tgz",
-      "integrity": "sha512-bpIGX+ov9PhJYV+wHNXl9rzq4F0QvILiURn0y0oepbQx+7stmQsKA0DhPGwmhfvF856wq+gbM8L92SAa/CBcLg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/unrun/node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.53.tgz",
-      "integrity": "sha512-bGe5EBB8FVjHBR1mOLOPEFg1Lp3//7geqWkU5NIhxe+yH0W8FVrQ6WRYOap4SUTKdklD/dC4qPLREkMMQ855FA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/unrun/node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.53.tgz",
-      "integrity": "sha512-qL+63WKVQs1CMvFedlPt0U9PiEKJOAL/bsHMKUDS6Vp2Q+YAv/QLPu8rcvkfIMvQ0FPU2WL0aX4eWwF6e/GAnA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/unrun/node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.53.tgz",
-      "integrity": "sha512-VGl9JIGjoJh3H8Mb+7xnVqODajBmrdOOb9lxWXdcmxyI+zjB2sux69br0hZJDTyLJfvBoYm439zPACYbCjGRmw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/unrun/node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.53.tgz",
-      "integrity": "sha512-B4iIserJXuSnNzA5xBLFUIjTfhNy7d9sq4FUMQY3GhQWGVhS2RWWzzDnkSU6MUt7/aHUrep0CdQfXUJI9D3W7A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/unrun/node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.53.tgz",
-      "integrity": "sha512-BUjAEgpABEJXilGq/BPh7jeU3WAJ5o15c1ZEgHaDWSz3LB881LQZnbNJHmUiM4d1JQWMYYyR1Y490IBHi2FPJg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/unrun/node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.53.tgz",
-      "integrity": "sha512-s27uU7tpCWSjHBnxyVXHt3rMrQdJq5MHNv3BzsewCIroIw3DJFjMH1dzCPPMUFxnh1r52Nf9IJ/eWp6LDoyGcw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/unrun/node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.53.tgz",
-      "integrity": "sha512-cjWL/USPJ1g0en2htb4ssMjIycc36RvdQAx1WlXnS6DpULswiUTVXPDesTifSKYSyvx24E0YqQkEm0K/M2Z/AA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/unrun/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
-      "integrity": "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/unrun/node_modules/rolldown": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.53.tgz",
-      "integrity": "sha512-Qd9c2p0XKZdgT5AYd+KgAMggJ8ZmCs3JnS9PTMWkyUfteKlfmKtxJbWTHkVakxwXs1Ub7jrRYVeFeF7N0sQxyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "=0.101.0",
-        "@rolldown/pluginutils": "1.0.0-beta.53"
-      },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-beta.53",
-        "@rolldown/binding-darwin-arm64": "1.0.0-beta.53",
-        "@rolldown/binding-darwin-x64": "1.0.0-beta.53",
-        "@rolldown/binding-freebsd-x64": "1.0.0-beta.53",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-beta.53",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-beta.53",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-beta.53",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.53",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-beta.53",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-beta.53",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-beta.53",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-beta.53",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-beta.53"
       }
     },
     "node_modules/validate-npm-package-name": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jsdom": "27.2.0",
     "lefthook": "2.0.4",
     "publint": "0.3.15",
-    "tsdown": "0.16.4",
+    "tsdown": "0.17.0",
     "turbo": "2.6.1",
     "vitest": "4.0.14"
   },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   publint: true,
   target: 'es2022',
   attw: {
-    profile: 'esmOnly',
+    profile: 'esm-only',
   },
+  unbundle: true,
 });


### PR DESCRIPTION
## Summary
- Update tsdown from 0.16.4 to 0.17.0
- Update config for breaking changes: `esmOnly` → `esm-only` profile
- Add `unbundle: true` option