### PR TITLE
build: enable type-aware linting and fix turbo dependencies

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,8 +15,13 @@ const licensePattern =
 export default [
   {
     files: ['packages/*/src/**/*.{js,ts,mjs}'],
+    ignores: ['**/*.test.ts', '**/*.spec.ts'],
     languageOptions: {
       parser: tseslint.parser,
+      // enables type-aware linting to detect instance method usage
+      parserOptions: {
+        projectService: true,
+      },
     },
     plugins: {
       'baseline-js': baselinePlugin,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8406,6 +8406,9 @@
         "@opentelemetry/api-logs": "*",
         "@opentelemetry/instrumentation": "*",
         "@opentelemetry/web-utils": "*"
+      },
+      "devDependencies": {
+        "@opentelemetry/test-utils": "*"
       }
     },
     "packages/test-utils": {

--- a/packages/instrumentation-user-action/package.json
+++ b/packages/instrumentation-user-action/package.json
@@ -38,6 +38,9 @@
     "@opentelemetry/instrumentation": "*",
     "@opentelemetry/web-utils": "*"
   },
+  "devDependencies": {
+    "@opentelemetry/test-utils": "*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,7 @@
       "outputs": ["dist/**"]
     },
     "check-types": {
-      "dependsOn": ["^check-types"]
+      "dependsOn": ["^build"]
     },
     "dev": {
       "persistent": true,


### PR DESCRIPTION
## Which problem is this PR solving?

Type-aware ESLint rules were not enabled, preventing detection of instance method usage issues. Additionally, turbo had an incorrect dependency.

## Short description of the changes

- Enable type-aware ESLint with `projectService` for source files (excluding tests)
- Fix turbo `check-types` task to depend on `^build` instead of `^check-types`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] CI passes