### PR TITLE
chore(biome): enable html formatter

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -37,6 +37,11 @@
       "tailwindDirectives": true
     }
   },
+  "html": {
+    "formatter": {
+      "enabled": true
+    }
+  },
   "linter": {
     "rules": {
       "security": {


### PR DESCRIPTION
## Which problem is this PR solving?

Enable HTML formatting in Biome for consistent HTML file formatting across the project.

## Short description of the changes

Add HTML formatter configuration to biome.jsonc with `enabled: true`.