### PR TITLE
fix(instrumentation-user-action): fix event handler during instantiation

### DIFF
--- a/packages/instrumentation-user-action/src/instrumentation.test.ts
+++ b/packages/instrumentation-user-action/src/instrumentation.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { SeverityNumber } from '@opentelemetry/api-logs';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { setupTestLogExporter } from '@opentelemetry/test-utils';
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
@@ -11,20 +12,20 @@ import { UserActionInstrumentation } from './instrumentation.ts';
 
 describe('UserActionInstrumentation', () => {
   let inMemoryExporter: InMemoryLogRecordExporter;
-  let instrumentation: UserActionInstrumentation;
+  let disableInstrumentations: () => void;
 
   beforeAll(() => {
     inMemoryExporter = setupTestLogExporter();
   });
 
   beforeEach(() => {
-    instrumentation = new UserActionInstrumentation();
-
-    instrumentation.enable();
+    disableInstrumentations = registerInstrumentations({
+      instrumentations: [new UserActionInstrumentation()],
+    });
   });
 
   afterEach(() => {
-    instrumentation.disable();
+    disableInstrumentations();
     inMemoryExporter.reset();
     document.body.innerHTML = '';
   });
@@ -129,7 +130,7 @@ describe('UserActionInstrumentation', () => {
 
   it('should not emit click logs when disabled', () => {
     // Disable previous instrumentation and create a new one with click disabled
-    instrumentation.disable();
+    disableInstrumentations();
     const disabledInstrumentation = new UserActionInstrumentation({
       autoCapturedActions: [],
     });


### PR DESCRIPTION

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The README.md advises to use the instrumentation like this:

```ts
registerInstrumentations({
  instrumentations: [
    new UserActionInstrumentation(),
  ],
});
```

But this does not work because the value passed to `addEventListener('click', ...)` is `undefined` when `enable()` is called.

This issue is similar to https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3322
See also comment https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3322#discussion_r2669379120.

## Short description of the changes


This commit fixes the issue by using the 'declare' typescript keyword on the `_onClickHandler` class property and initializing it in `enable()`.


## Type of change

Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have a small page where I am testing various Web otel instrumentations. I installed this patched version of the `instrumentation-user-action` to actually test it in a "real" setup.

I also updated unit tests to match the usage highlighted in the documentation.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
