### PR TITLE
chore(deps): tune renovate config for rebase strategy and ignored deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,10 +4,12 @@
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
-  "rebaseWhen": "conflicted",
+  "rebaseWhen": "behind-base-branch",
   "postUpdateOptions": ["npmDedupe"],
   "schedule": ["before 8am on Monday"],
   "labels": ["dependencies"],
+  "ignoreDeps": ["@types/node", "node", "npm"],
+  "rangeStrategy": "bump",
   "packageRules": [
     {
       "description": "GitHub Actions",


### PR DESCRIPTION
## Summary
- Change `rebaseWhen` from `conflicted` to `behind-base-branch` for more proactive rebasing
- Add `ignoreDeps` for `@types/node`, `node`, and `npm` to skip unnecessary version bumps
- Set `rangeStrategy` to `bump` for more predictable dependency updates

## Test plan
- [ ] Verify Renovate picks up the new config on next scheduled run
- [ ] Confirm ignored deps no longer generate PRs