### PR TITLE
chore: add npm to devEngines

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,13 @@
   "commitlint": {
     "extends": "@commitlint/config-conventional"
   },
-  "packageManager": "npm@11.10.1",
+  "packageManager": "npm@11.9.0",
   "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "^11.9.0",
+      "onFail": "error"
+    },
     "runtime": {
       "name": "node",
       "version": ">=24"


### PR DESCRIPTION
## Which problem is this PR solving?

The devEngines config was missing the packageManager field, so npm version constraints were not being enforced via devEngines.

## Short description of the changes

- Add `packageManager` to `devEngines` in package.json, requiring npm ^11.9.0 with `onFail: "error"`
- Update the `packageManager` field from npm@11.10.1 to npm@11.9.0

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Verified that `npm install` respects the devEngines constraint

## Checklist:

- [x] Followed the style guidelines of this project