### PR TITLE
ci(renovate): use replace range strategy for opentelemetry deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,7 +25,8 @@
     {
       "description": "OpenTelemetry",
       "matchDepNames": ["@opentelemetry/**"],
-      "groupName": "opentelemetry"
+      "groupName": "opentelemetry",
+      "rangeStrategy": "replace"
     }
   ]
 }


### PR DESCRIPTION
## Which problem is this PR solving?

The `config:best-practices` Renovate preset pins devDependencies by default. This caused `@opentelemetry/sdk-logs` to be pinned to an exact version (`0.213.0`) instead of using a caret range (`^0.213.0`), which is inconsistent with how all other OpenTelemetry dependencies are specified.

## Short description of the changes

Adds `"rangeStrategy": "replace"` to the OpenTelemetry package rule in `.github/renovate.json`. This ensures Renovate always uses the default npm range prefix (`^`) for OpenTelemetry packages, overriding the pin behavior from `config:best-practices`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Verified Renovate documentation confirms `replace` strategy uses the package manager's default range (`^` for npm)

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [x] Documentation has been updated