### PR TITLE
fix: allow requestIdleCallback in resource-timing dist baseline check

### DIFF
--- a/eslint.dist.config.js
+++ b/eslint.dist.config.js
@@ -19,4 +19,20 @@ export default [
       ],
     },
   },
+  // resource-timing intentionally uses requestIdleCallback (not widely available)
+  // with a Safari fallback shim — suppress the dist-level check for this package.
+  {
+    files: ['packages/instrumentation-resource-timing/dist/**/*.js'],
+    rules: {
+      'baseline-js/use-baseline': [
+        'error',
+        {
+          available: 'widely',
+          includeWebApis: { preset: 'auto' },
+          includeJsBuiltins: { preset: 'auto' },
+          ignoreFeatures: ['requestidlecallback'],
+        },
+      ],
+    },
+  },
 ];


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The `instrumentation-resource-timing` package intentionally uses `requestIdleCallback` (not Baseline widely available — no Safari support), with browser compatibility handled via an `idle-callback-shim.ts` setTimeout fallback. The dist-level ESLint baseline check (`check:eslint:dist`) runs on compiled output where `eslint-disable` comments do not survive bundling, causing false positive failures in CI.

## Short description of the changes

Adds a scoped override in `eslint.dist.config.js` that ignores the `requestidlecallback` feature ID for the `instrumentation-resource-timing` dist output only. All other packages remain fully covered by the baseline check.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`npm run check:eslint:dist` passes locally.

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated