### PR TITLE
feat: apply unified HTTP semantic conventions to resource timing

### DIFF
--- a/examples/all-instrumentations/index.html
+++ b/examples/all-instrumentations/index.html
@@ -13,6 +13,7 @@
       <button id="test-button" type="button">Test Click</button>
       <button id="xhr-button" type="button">Send XHR</button>
       <button id="fetch-button" type="button">Send Fetch</button>
+      <button id="img-button" type="button">Load Image</button>
     </open-telemetry>
   </body>
 </html>

--- a/examples/all-instrumentations/src/main.ts
+++ b/examples/all-instrumentations/src/main.ts
@@ -23,20 +23,30 @@ logs.setGlobalLoggerProvider(loggerProvider);
 registerInstrumentations({
   instrumentations: [
     new NavigationTimingInstrumentation(),
-    new ResourceTimingInstrumentation({
-      initiatorTypes: ['xmlhttprequest', 'fetch'],
-    }),
+    new ResourceTimingInstrumentation(),
     new UserActionInstrumentation(),
     new WebVitalsInstrumentation({ includeRawAttribution: true }),
   ],
 });
 
+// Use /api proxy (same-origin) so the browser exposes full timing data.
+// Cross-origin requests hide DNS, connect, TLS, and size details unless
+// the server sends Timing-Allow-Origin.
+
 document.getElementById('xhr-button')?.addEventListener('click', () => {
   const xhr = new XMLHttpRequest();
-  xhr.open('GET', 'https://httpbin.org/get');
+  xhr.open('GET', '/api/get');
   xhr.send();
 });
 
 document.getElementById('fetch-button')?.addEventListener('click', () => {
-  fetch('https://httpbin.org/get');
+  fetch('/api/get');
+});
+
+document.getElementById('img-button')?.addEventListener('click', () => {
+  const img = document.createElement('img');
+  // httpbin /image/png returns a PNG; loaded via same-origin proxy
+  img.src = `/api/image/png?cachebust=${Date.now()}`;
+  img.style.display = 'none';
+  document.body.appendChild(img);
 });

--- a/examples/all-instrumentations/vite.config.ts
+++ b/examples/all-instrumentations/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    proxy: {
+      // Proxy /api to httpbin so requests are same-origin.
+      // Same-origin requests expose full PerformanceResourceTiming data
+      // (DNS, connect, TLS, request/response phases, sizes).
+      '/api': {
+        target: 'https://httpbin.org',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
+});

--- a/packages/instrumentation/src/resource-timing/instrumentation.test.ts
+++ b/packages/instrumentation/src/resource-timing/instrumentation.test.ts
@@ -17,9 +17,24 @@ import { setupTestLogExporter } from '#instrumentation-test-utils';
 import * as shimModule from './idle-callback-shim.ts';
 import { ResourceTimingInstrumentation } from './instrumentation.ts';
 import {
+  ATTR_NETWORK_PROTOCOL_NAME,
+  ATTR_NETWORK_PROTOCOL_VERSION,
+  ATTR_RESOURCE_CONNECT_END,
+  ATTR_RESOURCE_CONNECT_START,
+  ATTR_RESOURCE_DOMAIN_LOOKUP_END,
+  ATTR_RESOURCE_DOMAIN_LOOKUP_START,
   ATTR_RESOURCE_DURATION,
+  ATTR_RESOURCE_FETCH_START,
+  ATTR_RESOURCE_REDIRECT_END,
+  ATTR_RESOURCE_REDIRECT_START,
+  ATTR_RESOURCE_RENDER_BLOCKING_STATUS,
+  ATTR_RESOURCE_REQUEST_START,
+  ATTR_RESOURCE_RESPONSE_END,
+  ATTR_RESOURCE_RESPONSE_START,
+  ATTR_RESOURCE_SECURE_CONNECTION_START,
   ATTR_RESOURCE_TRANSFER_SIZE,
   ATTR_RESOURCE_URL,
+  ATTR_RESOURCE_WORKER_START,
   RESOURCE_TIMING_EVENT_NAME,
 } from './semconv.ts';
 
@@ -31,6 +46,8 @@ function triggerIdleCallback(timeRemaining = 10, didTimeout = false): void {
     .lastCall?.[0];
   callback?.({ timeRemaining: () => timeRemaining, didTimeout });
 }
+
+const MOCK_TIME_ORIGIN = 1700000000000;
 
 describe('ResourceTimingInstrumentation', () => {
   let instrumentation: ResourceTimingInstrumentation;
@@ -86,6 +103,11 @@ describe('ResourceTimingInstrumentation', () => {
     });
 
     vi.stubGlobal('PerformanceObserver', PerformanceObserverMock);
+
+    vi.stubGlobal('performance', {
+      now: vi.fn(() => 0),
+      timeOrigin: MOCK_TIME_ORIGIN,
+    });
   });
 
   afterEach(() => {
@@ -383,7 +405,7 @@ describe('ResourceTimingInstrumentation', () => {
   });
 
   describe('Data Emission', () => {
-    it('should emit log records with correct attributes', () => {
+    it('should emit log records with correct event name and basic attributes', () => {
       instrumentation = new ResourceTimingInstrumentation();
       instrumentation.enable();
 
@@ -410,6 +432,200 @@ describe('ResourceTimingInstrumentation', () => {
       expect(
         (records[0] as unknown as { eventName: string } | undefined)?.eventName,
       ).toBe(RESOURCE_TIMING_EVENT_NAME);
+    });
+
+    it('should compute http.call.start_time as absolute timestamp (timeOrigin + fetchStart)', () => {
+      instrumentation = new ResourceTimingInstrumentation();
+      instrumentation.enable();
+
+      const mockEntry = createMockResourceEntry({
+        fetchStart: 100,
+      });
+
+      observerCallback(
+        createMockPerformanceObserverEntryList([mockEntry]),
+        mockObserver as unknown as PerformanceObserver,
+      );
+
+      triggerIdleCallback(10);
+
+      const records = inMemoryExporter.getFinishedLogRecords();
+      expect(records).toHaveLength(1);
+      expect(records[0]?.attributes[ATTR_RESOURCE_FETCH_START]).toBe(
+        MOCK_TIME_ORIGIN + 100,
+      );
+    });
+
+    it('should compute timing attributes as deltas from fetchStart', () => {
+      instrumentation = new ResourceTimingInstrumentation();
+      instrumentation.enable();
+
+      const mockEntry = createMockResourceEntry({
+        fetchStart: 100,
+        domainLookupStart: 110,
+        domainLookupEnd: 120,
+        connectStart: 120,
+        connectEnd: 140,
+        requestStart: 140,
+        responseStart: 160,
+        responseEnd: 200,
+      });
+
+      observerCallback(
+        createMockPerformanceObserverEntryList([mockEntry]),
+        mockObserver as unknown as PerformanceObserver,
+      );
+
+      triggerIdleCallback(10);
+
+      const records = inMemoryExporter.getFinishedLogRecords();
+      expect(records).toHaveLength(1);
+      const attrs = records[0]?.attributes;
+
+      // All timing values should be relative to fetchStart (100)
+      expect(attrs?.[ATTR_RESOURCE_DOMAIN_LOOKUP_START]).toBe(10); // 110 - 100
+      expect(attrs?.[ATTR_RESOURCE_DOMAIN_LOOKUP_END]).toBe(20); // 120 - 100
+      expect(attrs?.[ATTR_RESOURCE_CONNECT_START]).toBe(20); // 120 - 100
+      expect(attrs?.[ATTR_RESOURCE_CONNECT_END]).toBe(40); // 140 - 100
+      expect(attrs?.[ATTR_RESOURCE_REQUEST_START]).toBe(40); // 140 - 100
+      expect(attrs?.[ATTR_RESOURCE_RESPONSE_START]).toBe(60); // 160 - 100
+      expect(attrs?.[ATTR_RESOURCE_RESPONSE_END]).toBe(100); // 200 - 100
+    });
+
+    it('should omit timing attributes when browser API returns 0 (phase did not occur)', () => {
+      instrumentation = new ResourceTimingInstrumentation();
+      instrumentation.enable();
+
+      const mockEntry = createMockResourceEntry({
+        fetchStart: 100,
+        // These are 0 → phase did not occur → should be omitted
+        redirectStart: 0,
+        redirectEnd: 0,
+        secureConnectionStart: 0,
+        workerStart: 0,
+        // These are non-zero → should be present
+        domainLookupStart: 110,
+        domainLookupEnd: 120,
+        connectStart: 120,
+        connectEnd: 130,
+        requestStart: 130,
+        responseStart: 150,
+        responseEnd: 200,
+      });
+
+      observerCallback(
+        createMockPerformanceObserverEntryList([mockEntry]),
+        mockObserver as unknown as PerformanceObserver,
+      );
+
+      triggerIdleCallback(10);
+
+      const records = inMemoryExporter.getFinishedLogRecords();
+      expect(records).toHaveLength(1);
+      const attrs = records[0]?.attributes;
+
+      // Omitted (value was 0)
+      expect(attrs?.[ATTR_RESOURCE_REDIRECT_START]).toBeUndefined();
+      expect(attrs?.[ATTR_RESOURCE_REDIRECT_END]).toBeUndefined();
+      expect(attrs?.[ATTR_RESOURCE_SECURE_CONNECTION_START]).toBeUndefined();
+      expect(attrs?.[ATTR_RESOURCE_WORKER_START]).toBeUndefined();
+
+      // Present (non-zero)
+      expect(attrs?.[ATTR_RESOURCE_DOMAIN_LOOKUP_START]).toBe(10);
+      expect(attrs?.[ATTR_RESOURCE_DOMAIN_LOOKUP_END]).toBe(20);
+      expect(attrs?.[ATTR_RESOURCE_CONNECT_START]).toBe(20);
+      expect(attrs?.[ATTR_RESOURCE_CONNECT_END]).toBe(30);
+      expect(attrs?.[ATTR_RESOURCE_REQUEST_START]).toBe(30);
+      expect(attrs?.[ATTR_RESOURCE_RESPONSE_START]).toBe(50);
+    });
+
+    it('should parse nextHopProtocol with slash into name and version', () => {
+      instrumentation = new ResourceTimingInstrumentation();
+      instrumentation.enable();
+
+      const mockEntry = createMockResourceEntry({
+        nextHopProtocol: 'http/1.1',
+      });
+
+      observerCallback(
+        createMockPerformanceObserverEntryList([mockEntry]),
+        mockObserver as unknown as PerformanceObserver,
+      );
+
+      triggerIdleCallback(10);
+
+      const records = inMemoryExporter.getFinishedLogRecords();
+      expect(records).toHaveLength(1);
+      expect(records[0]?.attributes[ATTR_NETWORK_PROTOCOL_NAME]).toBe('http');
+      expect(records[0]?.attributes[ATTR_NETWORK_PROTOCOL_VERSION]).toBe('1.1');
+    });
+
+    it('should parse nextHopProtocol without slash as name only', () => {
+      instrumentation = new ResourceTimingInstrumentation();
+      instrumentation.enable();
+
+      const mockEntry = createMockResourceEntry({
+        nextHopProtocol: 'h2',
+      });
+
+      observerCallback(
+        createMockPerformanceObserverEntryList([mockEntry]),
+        mockObserver as unknown as PerformanceObserver,
+      );
+
+      triggerIdleCallback(10);
+
+      const records = inMemoryExporter.getFinishedLogRecords();
+      expect(records).toHaveLength(1);
+      expect(records[0]?.attributes[ATTR_NETWORK_PROTOCOL_NAME]).toBe('h2');
+      expect(
+        records[0]?.attributes[ATTR_NETWORK_PROTOCOL_VERSION],
+      ).toBeUndefined();
+    });
+
+    it('should omit protocol attributes when nextHopProtocol is empty', () => {
+      instrumentation = new ResourceTimingInstrumentation();
+      instrumentation.enable();
+
+      const mockEntry = createMockResourceEntry({
+        nextHopProtocol: '',
+      });
+
+      observerCallback(
+        createMockPerformanceObserverEntryList([mockEntry]),
+        mockObserver as unknown as PerformanceObserver,
+      );
+
+      triggerIdleCallback(10);
+
+      const records = inMemoryExporter.getFinishedLogRecords();
+      expect(records).toHaveLength(1);
+      expect(
+        records[0]?.attributes[ATTR_NETWORK_PROTOCOL_NAME],
+      ).toBeUndefined();
+      expect(
+        records[0]?.attributes[ATTR_NETWORK_PROTOCOL_VERSION],
+      ).toBeUndefined();
+    });
+
+    it('should include renderBlockingStatus when available', () => {
+      instrumentation = new ResourceTimingInstrumentation();
+      instrumentation.enable();
+
+      const mockEntry = createMockResourceEntry({}, 'blocking');
+
+      observerCallback(
+        createMockPerformanceObserverEntryList([mockEntry]),
+        mockObserver as unknown as PerformanceObserver,
+      );
+
+      triggerIdleCallback(10);
+
+      const records = inMemoryExporter.getFinishedLogRecords();
+      expect(records).toHaveLength(1);
+      expect(records[0]?.attributes[ATTR_RESOURCE_RENDER_BLOCKING_STATUS]).toBe(
+        'blocking',
+      );
     });
 
     it('should flush on visibility change', () => {
@@ -544,6 +760,7 @@ describe('ResourceTimingInstrumentation', () => {
 
 function createMockResourceEntry(
   overrides: Partial<PerformanceResourceTiming> = {},
+  renderBlockingStatus = 'non-blocking',
 ): PerformanceResourceTiming {
   return {
     name: 'https://example.com/resource.js',
@@ -552,7 +769,8 @@ function createMockResourceEntry(
     duration: 100,
     initiatorType: 'script',
     nextHopProtocol: 'h2',
-    renderBlockingStatus: 'non-blocking',
+    // renderBlockingStatus is Chromium-only, not in the TS type definition
+    renderBlockingStatus,
     responseStatus: 200,
     deliveryType: '',
     fetchStart: 0,

--- a/packages/instrumentation/src/resource-timing/instrumentation.ts
+++ b/packages/instrumentation/src/resource-timing/instrumentation.ts
@@ -30,6 +30,7 @@ import {
   ATTR_RESOURCE_RENDER_BLOCKING_STATUS,
   ATTR_RESOURCE_REQUEST_START,
   ATTR_RESOURCE_RESPONSE_END,
+  ATTR_RESOURCE_RESPONSE_STATUS,
   ATTR_RESOURCE_RESPONSE_START,
   ATTR_RESOURCE_SECURE_CONNECTION_START,
   ATTR_RESOURCE_TRANSFER_SIZE,
@@ -254,6 +255,11 @@ export class ResourceTimingInstrumentation extends InstrumentationBase<ResourceT
         [ATTR_RESOURCE_ENCODED_BODY_SIZE]: entry.encodedBodySize,
         [ATTR_RESOURCE_DECODED_BODY_SIZE]: entry.decodedBodySize,
       };
+
+      // responseStatus is 0 for cross-origin resources without Timing-Allow-Origin
+      if (entry.responseStatus !== 0) {
+        attributes[ATTR_RESOURCE_RESPONSE_STATUS] = entry.responseStatus;
+      }
 
       // Timing phases: omit when browser API returns 0 (phase did not occur).
       // Non-zero values are converted to deltas from fetchStart.

--- a/packages/instrumentation/src/resource-timing/instrumentation.ts
+++ b/packages/instrumentation/src/resource-timing/instrumentation.ts
@@ -17,6 +17,7 @@ import {
   ATTR_NETWORK_PROTOCOL_VERSION,
   ATTR_RESOURCE_CONNECT_END,
   ATTR_RESOURCE_CONNECT_START,
+  ATTR_RESOURCE_CONTENT_TYPE,
   ATTR_RESOURCE_DECODED_BODY_SIZE,
   ATTR_RESOURCE_DOMAIN_LOOKUP_END,
   ATTR_RESOURCE_DOMAIN_LOOKUP_START,
@@ -305,7 +306,13 @@ export class ResourceTimingInstrumentation extends InstrumentationBase<ResourceT
         }
       }
 
-      // Chromium-only field
+      // contentType is not yet in all TS type definitions
+      const contentType = (entry as { contentType?: string }).contentType;
+      if (contentType) {
+        attributes[ATTR_RESOURCE_CONTENT_TYPE] = contentType;
+      }
+
+      // renderBlockingStatus is Chromium-only
       const renderBlockingStatus = (entry as { renderBlockingStatus?: string })
         .renderBlockingStatus;
       if (renderBlockingStatus) {

--- a/packages/instrumentation/src/resource-timing/instrumentation.ts
+++ b/packages/instrumentation/src/resource-timing/instrumentation.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { Attributes } from '@opentelemetry/api';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { InstrumentationBase } from '@opentelemetry/instrumentation';
 import { version } from '../../package.json' with { type: 'json' };
@@ -12,6 +13,8 @@ import {
   requestIdleCallbackShim,
 } from './idle-callback-shim.ts';
 import {
+  ATTR_NETWORK_PROTOCOL_NAME,
+  ATTR_NETWORK_PROTOCOL_VERSION,
   ATTR_RESOURCE_CONNECT_END,
   ATTR_RESOURCE_CONNECT_START,
   ATTR_RESOURCE_DECODED_BODY_SIZE,
@@ -21,7 +24,6 @@ import {
   ATTR_RESOURCE_ENCODED_BODY_SIZE,
   ATTR_RESOURCE_FETCH_START,
   ATTR_RESOURCE_INITIATOR_TYPE,
-  ATTR_RESOURCE_NEXT_HOP_PROTOCOL,
   ATTR_RESOURCE_REDIRECT_END,
   ATTR_RESOURCE_REDIRECT_START,
   ATTR_RESOURCE_RENDER_BLOCKING_STATUS,
@@ -53,6 +55,12 @@ const MIN_QUEUE_SIZE = 1;
  * and batches emissions to avoid overwhelming the main thread. It uses
  * requestIdleCallback when available (with fallback for Safari) to ensure
  * processing happens during idle periods.
+ *
+ * Timing attributes follow the unified HTTP client network timing conventions
+ * from https://github.com/open-telemetry/semantic-conventions/issues/3385:
+ * - http.call.start_time is an absolute timestamp (ms since epoch)
+ * - All other timing attributes are deltas from http.call.start_time
+ * - Browser API values of 0 (phase did not occur) are omitted
  */
 export class ResourceTimingInstrumentation extends InstrumentationBase<ResourceTimingInstrumentationConfig> {
   private _observer?: PerformanceObserver;
@@ -234,32 +242,80 @@ export class ResourceTimingInstrumentation extends InstrumentationBase<ResourceT
 
   private _emitResource(entry: PerformanceResourceTiming): void {
     try {
+      const fetchStart = entry.fetchStart;
+      const attributes: Attributes = {
+        [ATTR_RESOURCE_URL]: entry.name,
+        [ATTR_RESOURCE_INITIATOR_TYPE]: entry.initiatorType,
+        [ATTR_RESOURCE_DURATION]: entry.duration,
+        [ATTR_RESOURCE_FETCH_START]: performance.timeOrigin + fetchStart,
+        [ATTR_RESOURCE_RESPONSE_END]: entry.responseEnd - fetchStart,
+        [ATTR_RESOURCE_TRANSFER_SIZE]: entry.transferSize,
+        [ATTR_RESOURCE_ENCODED_BODY_SIZE]: entry.encodedBodySize,
+        [ATTR_RESOURCE_DECODED_BODY_SIZE]: entry.decodedBodySize,
+      };
+
+      // Timing phases: omit when browser API returns 0 (phase did not occur).
+      // Non-zero values are converted to deltas from fetchStart.
+      if (entry.redirectStart !== 0) {
+        attributes[ATTR_RESOURCE_REDIRECT_START] =
+          entry.redirectStart - fetchStart;
+      }
+      if (entry.redirectEnd !== 0) {
+        attributes[ATTR_RESOURCE_REDIRECT_END] = entry.redirectEnd - fetchStart;
+      }
+      if (entry.domainLookupStart !== 0) {
+        attributes[ATTR_RESOURCE_DOMAIN_LOOKUP_START] =
+          entry.domainLookupStart - fetchStart;
+      }
+      if (entry.domainLookupEnd !== 0) {
+        attributes[ATTR_RESOURCE_DOMAIN_LOOKUP_END] =
+          entry.domainLookupEnd - fetchStart;
+      }
+      if (entry.connectStart !== 0) {
+        attributes[ATTR_RESOURCE_CONNECT_START] =
+          entry.connectStart - fetchStart;
+      }
+      if (entry.connectEnd !== 0) {
+        attributes[ATTR_RESOURCE_CONNECT_END] = entry.connectEnd - fetchStart;
+      }
+      if (entry.secureConnectionStart !== 0) {
+        attributes[ATTR_RESOURCE_SECURE_CONNECTION_START] =
+          entry.secureConnectionStart - fetchStart;
+      }
+      if (entry.requestStart !== 0) {
+        attributes[ATTR_RESOURCE_REQUEST_START] =
+          entry.requestStart - fetchStart;
+      }
+      if (entry.responseStart !== 0) {
+        attributes[ATTR_RESOURCE_RESPONSE_START] =
+          entry.responseStart - fetchStart;
+      }
+      if (entry.workerStart !== 0) {
+        attributes[ATTR_RESOURCE_WORKER_START] = entry.workerStart - fetchStart;
+      }
+
+      // Protocol: parse nextHopProtocol into name and version
+      if (entry.nextHopProtocol) {
+        const { name, version: protocolVersion } = parseProtocol(
+          entry.nextHopProtocol,
+        );
+        attributes[ATTR_NETWORK_PROTOCOL_NAME] = name;
+        if (protocolVersion) {
+          attributes[ATTR_NETWORK_PROTOCOL_VERSION] = protocolVersion;
+        }
+      }
+
+      // Chromium-only field
+      const renderBlockingStatus = (entry as { renderBlockingStatus?: string })
+        .renderBlockingStatus;
+      if (renderBlockingStatus) {
+        attributes[ATTR_RESOURCE_RENDER_BLOCKING_STATUS] = renderBlockingStatus;
+      }
+
       this.logger.emit({
         eventName: RESOURCE_TIMING_EVENT_NAME,
         severityNumber: SeverityNumber.INFO,
-        attributes: {
-          [ATTR_RESOURCE_URL]: entry.name,
-          [ATTR_RESOURCE_INITIATOR_TYPE]: entry.initiatorType,
-          [ATTR_RESOURCE_DURATION]: entry.duration,
-          [ATTR_RESOURCE_FETCH_START]: entry.fetchStart,
-          [ATTR_RESOURCE_DOMAIN_LOOKUP_START]: entry.domainLookupStart,
-          [ATTR_RESOURCE_DOMAIN_LOOKUP_END]: entry.domainLookupEnd,
-          [ATTR_RESOURCE_CONNECT_START]: entry.connectStart,
-          [ATTR_RESOURCE_CONNECT_END]: entry.connectEnd,
-          [ATTR_RESOURCE_SECURE_CONNECTION_START]: entry.secureConnectionStart,
-          [ATTR_RESOURCE_REQUEST_START]: entry.requestStart,
-          [ATTR_RESOURCE_RESPONSE_START]: entry.responseStart,
-          [ATTR_RESOURCE_RESPONSE_END]: entry.responseEnd,
-          [ATTR_RESOURCE_TRANSFER_SIZE]: entry.transferSize,
-          [ATTR_RESOURCE_ENCODED_BODY_SIZE]: entry.encodedBodySize,
-          [ATTR_RESOURCE_DECODED_BODY_SIZE]: entry.decodedBodySize,
-          [ATTR_RESOURCE_REDIRECT_START]: entry.redirectStart,
-          [ATTR_RESOURCE_REDIRECT_END]: entry.redirectEnd,
-          [ATTR_RESOURCE_WORKER_START]: entry.workerStart,
-          [ATTR_RESOURCE_NEXT_HOP_PROTOCOL]: entry.nextHopProtocol,
-          // @ts-expect-error renderBlockingStatus is only available in Chromium as of March 2026
-          [ATTR_RESOURCE_RENDER_BLOCKING_STATUS]: entry.renderBlockingStatus,
-        },
+        attributes,
       });
     } catch (error) {
       this._diag.error(
@@ -284,4 +340,27 @@ export class ResourceTimingInstrumentation extends InstrumentationBase<ResourceT
       this._idleHandle = undefined;
     }
   }
+}
+
+/**
+ * Parse a nextHopProtocol string into protocol name and version.
+ *
+ * Examples:
+ *   "h2"      → { name: "h2" }
+ *   "h3"      → { name: "h3" }
+ *   "http/1.1" → { name: "http", version: "1.1" }
+ *   "http/1.0" → { name: "http", version: "1.0" }
+ */
+function parseProtocol(protocol: string): {
+  name: string;
+  version: string | undefined;
+} {
+  const slashIndex = protocol.indexOf('/');
+  if (slashIndex === -1) {
+    return { name: protocol, version: undefined };
+  }
+  return {
+    name: protocol.substring(0, slashIndex),
+    version: protocol.substring(slashIndex + 1),
+  };
 }

--- a/packages/instrumentation/src/resource-timing/semconv.ts
+++ b/packages/instrumentation/src/resource-timing/semconv.ts
@@ -6,6 +6,16 @@
 /*
  * This file contains a copy of unstable semantic convention definitions
  * used by this package.
+ *
+ * Timing attributes follow the unified HTTP client network timing conventions
+ * from https://github.com/open-telemetry/semantic-conventions/issues/3385
+ *
+ * The constants are exported under two names:
+ *   1. The canonical semconv name (e.g. ATTR_HTTP_CALL_START_TIME)
+ *   2. A descriptive alias that maps to the PerformanceResourceTiming API
+ *      field (e.g. ATTR_RESOURCE_FETCH_START) — used in instrumentation code
+ *      for readability.
+ *
  * @see https://github.com/open-telemetry/opentelemetry-js/tree/main/semantic-conventions#unstable-semconv
  */
 
@@ -14,151 +24,217 @@
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const RESOURCE_TIMING_EVENT_NAME = 'browser.resource.timing';
+export const RESOURCE_TIMING_EVENT_NAME = 'browser.resource_timing';
 
-// Resource timing attributes
+// ---------------------------------------------------------------------------
+// Timing attributes (unified HTTP client network timing conventions)
+//
+// `http.call.start_time` is an absolute timestamp (ms since epoch).
+// All other timing attributes are deltas from `http.call.start_time`.
+// Browser API values of 0 mean the phase did not occur — the attribute
+// SHOULD be omitted.
+// ---------------------------------------------------------------------------
 
 /**
- * The URL of the resource
+ * Absolute timestamp (ms since epoch) when the resource fetch started.
+ * Maps to: performance.timeOrigin + PerformanceResourceTiming.fetchStart
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_RESOURCE_URL = 'browser.resource.url';
+export const ATTR_HTTP_CALL_START_TIME = 'http.call.start_time';
+export const ATTR_RESOURCE_FETCH_START = ATTR_HTTP_CALL_START_TIME;
+
+/**
+ * Delta (ms) from http.call.start_time to when the response finished.
+ * Maps to: PerformanceResourceTiming.responseEnd - fetchStart
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_CALL_END_TIME = 'http.call.end_time';
+export const ATTR_RESOURCE_RESPONSE_END = ATTR_HTTP_CALL_END_TIME;
+
+/**
+ * Total duration of the resource load (in milliseconds).
+ * Maps to: PerformanceResourceTiming.duration
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_CALL_DURATION = 'http.call.duration';
+export const ATTR_RESOURCE_DURATION = ATTR_HTTP_CALL_DURATION;
+
+/**
+ * Delta (ms) from http.call.start_time to redirect start.
+ * Omit if 0 (no redirect). Browser only.
+ * Maps to: PerformanceResourceTiming.redirectStart - fetchStart
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_REDIRECT_START_TIME = 'http.redirect.start_time';
+export const ATTR_RESOURCE_REDIRECT_START = ATTR_HTTP_REDIRECT_START_TIME;
+
+/**
+ * Delta (ms) from http.call.start_time to redirect end.
+ * Omit if 0 (no redirect). Browser only.
+ * Maps to: PerformanceResourceTiming.redirectEnd - fetchStart
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_REDIRECT_END_TIME = 'http.redirect.end_time';
+export const ATTR_RESOURCE_REDIRECT_END = ATTR_HTTP_REDIRECT_END_TIME;
+
+/**
+ * Delta (ms) from http.call.start_time to domain lookup start.
+ * Omit if 0 (reused connection).
+ * Maps to: PerformanceResourceTiming.domainLookupStart - fetchStart
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_DNS_START_TIME = 'http.dns.start_time';
+export const ATTR_RESOURCE_DOMAIN_LOOKUP_START = ATTR_HTTP_DNS_START_TIME;
+
+/**
+ * Delta (ms) from http.call.start_time to domain lookup end.
+ * Maps to: PerformanceResourceTiming.domainLookupEnd - fetchStart
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_DNS_END_TIME = 'http.dns.end_time';
+export const ATTR_RESOURCE_DOMAIN_LOOKUP_END = ATTR_HTTP_DNS_END_TIME;
+
+/**
+ * Delta (ms) from http.call.start_time to connection start.
+ * Maps to: PerformanceResourceTiming.connectStart - fetchStart
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_CONNECT_START_TIME = 'http.connect.start_time';
+export const ATTR_RESOURCE_CONNECT_START = ATTR_HTTP_CONNECT_START_TIME;
+
+/**
+ * Delta (ms) from http.call.start_time to connection end.
+ * Maps to: PerformanceResourceTiming.connectEnd - fetchStart
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_CONNECT_END_TIME = 'http.connect.end_time';
+export const ATTR_RESOURCE_CONNECT_END = ATTR_HTTP_CONNECT_END_TIME;
+
+/**
+ * Delta (ms) from http.call.start_time to secure connection start.
+ * HTTPS only, omit if 0.
+ * Maps to: PerformanceResourceTiming.secureConnectionStart - fetchStart
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_SECURE_CONNECT_START_TIME =
+  'http.secure_connect.start_time';
+export const ATTR_RESOURCE_SECURE_CONNECTION_START =
+  ATTR_HTTP_SECURE_CONNECT_START_TIME;
+
+/**
+ * Delta (ms) from http.call.start_time to request start.
+ * Maps to: PerformanceResourceTiming.requestStart - fetchStart
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_REQUEST_HEADERS_START_TIME =
+  'http.request.headers.start_time';
+export const ATTR_RESOURCE_REQUEST_START = ATTR_HTTP_REQUEST_HEADERS_START_TIME;
+
+/**
+ * Delta (ms) from http.call.start_time to response start (first byte / TTFB).
+ * Maps to: PerformanceResourceTiming.responseStart - fetchStart
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_RESPONSE_HEADERS_START_TIME =
+  'http.response.headers.start_time';
+export const ATTR_RESOURCE_RESPONSE_START =
+  ATTR_HTTP_RESPONSE_HEADERS_START_TIME;
+
+/**
+ * Delta (ms) from http.call.start_time to service worker start.
+ * Omit if 0 (no service worker). Browser only.
+ * Maps to: PerformanceResourceTiming.workerStart - fetchStart
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_WORKER_START_TIME = 'http.worker.start_time';
+export const ATTR_RESOURCE_WORKER_START = ATTR_HTTP_WORKER_START_TIME;
+
+// ---------------------------------------------------------------------------
+// Size attributes
+// ---------------------------------------------------------------------------
+
+/**
+ * Transfer size in bytes (including headers).
+ * Maps to: PerformanceResourceTiming.transferSize
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_RESPONSE_SIZE = 'http.response.size';
+export const ATTR_RESOURCE_TRANSFER_SIZE = ATTR_HTTP_RESPONSE_SIZE;
+
+/**
+ * Encoded body size in bytes (compressed).
+ * Maps to: PerformanceResourceTiming.encodedBodySize
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_RESPONSE_BODY_SIZE = 'http.response.body.size';
+export const ATTR_RESOURCE_ENCODED_BODY_SIZE = ATTR_HTTP_RESPONSE_BODY_SIZE;
+
+/**
+ * Decoded body size in bytes (uncompressed).
+ * Maps to: PerformanceResourceTiming.decodedBodySize
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_RESOURCE_DECODED_BODY_SIZE =
+  'http.response.body.decoded_size';
+
+// ---------------------------------------------------------------------------
+// Resource metadata attributes
+// ---------------------------------------------------------------------------
+
+/**
+ * The full URL of the resource.
+ * Maps to: PerformanceResourceTiming.name
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_URL_FULL = 'url.full';
+export const ATTR_RESOURCE_URL = ATTR_URL_FULL;
+
+/**
+ * Network protocol name (e.g. "h2", "http").
+ * Parsed from: PerformanceResourceTiming.nextHopProtocol
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_NETWORK_PROTOCOL_NAME = 'network.protocol.name';
+
+/**
+ * Network protocol version (e.g. "1.1", "2").
+ * Parsed from: PerformanceResourceTiming.nextHopProtocol
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_NETWORK_PROTOCOL_VERSION = 'network.protocol.version';
 
 /**
  * The type of resource (script, stylesheet, img, xmlhttprequest, fetch, etc.)
+ * Browser-specific attribute.
+ * Maps to: PerformanceResourceTiming.initiatorType
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RESOURCE_INITIATOR_TYPE = 'browser.resource.initiator_type';
 
 /**
- * Total duration of the resource load (in milliseconds)
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_DURATION = 'browser.resource.duration';
-
-/**
- * Start time of the resource fetch (relative to navigation start)
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_FETCH_START = 'browser.resource.fetch_start';
-
-/**
- * Domain lookup start time
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_DOMAIN_LOOKUP_START =
-  'browser.resource.domain_lookup_start';
-
-/**
- * Domain lookup end time
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_DOMAIN_LOOKUP_END =
-  'browser.resource.domain_lookup_end';
-
-/**
- * Connection start time
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_CONNECT_START = 'browser.resource.connect_start';
-
-/**
- * Connection end time
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_CONNECT_END = 'browser.resource.connect_end';
-
-/**
- * Secure connection start time (HTTPS)
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_SECURE_CONNECTION_START =
-  'browser.resource.secure_connection_start';
-
-/**
- * Request start time
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_REQUEST_START = 'browser.resource.request_start';
-
-/**
- * Response start time
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_RESPONSE_START = 'browser.resource.response_start';
-
-/**
- * Response end time
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_RESPONSE_END = 'browser.resource.response_end';
-
-/**
- * Transfer size in bytes (including headers)
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_TRANSFER_SIZE = 'browser.resource.transfer_size';
-
-/**
- * Encoded body size in bytes (compressed)
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_ENCODED_BODY_SIZE =
-  'browser.resource.encoded_body_size';
-
-/**
- * Decoded body size in bytes (uncompressed)
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_DECODED_BODY_SIZE =
-  'browser.resource.decoded_body_size';
-
-/**
- * Redirect start time
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_REDIRECT_START = 'browser.resource.redirect_start';
-
-/**
- * Redirect end time
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_REDIRECT_END = 'browser.resource.redirect_end';
-
-/**
- * Worker start time (for Service Worker interception)
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_WORKER_START = 'browser.resource.worker_start';
-
-/**
- * Next hop protocol (h2, h3, http/1.1, etc.)
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RESOURCE_NEXT_HOP_PROTOCOL =
-  'browser.resource.next_hop_protocol';
-
-/**
- * Render blocking status (blocking, non-blocking)
+ * Render blocking status (blocking, non-blocking).
+ * Browser-specific attribute. Chromium only as of March 2026.
+ * Maps to: PerformanceResourceTiming.renderBlockingStatus
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */

--- a/packages/instrumentation/src/resource-timing/semconv.ts
+++ b/packages/instrumentation/src/resource-timing/semconv.ts
@@ -236,6 +236,16 @@ export const ATTR_NETWORK_PROTOCOL_VERSION = 'network.protocol.version';
 export const ATTR_RESOURCE_INITIATOR_TYPE = 'browser.resource.initiator_type';
 
 /**
+ * Content type of the response.
+ * Maps to: PerformanceResourceTiming.contentType
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_RESPONSE_HEADER_CONTENT_TYPE =
+  'http.response.header.content-type';
+export const ATTR_RESOURCE_CONTENT_TYPE = ATTR_HTTP_RESPONSE_HEADER_CONTENT_TYPE;
+
+/**
  * Render blocking status (blocking, non-blocking).
  * Browser-specific attribute. Chromium only as of March 2026.
  * Maps to: PerformanceResourceTiming.renderBlockingStatus

--- a/packages/instrumentation/src/resource-timing/semconv.ts
+++ b/packages/instrumentation/src/resource-timing/semconv.ts
@@ -176,22 +176,26 @@ export const ATTR_HTTP_RESPONSE_SIZE = 'http.response.size';
 export const ATTR_RESOURCE_TRANSFER_SIZE = ATTR_HTTP_RESPONSE_SIZE;
 
 /**
- * Encoded body size in bytes (compressed).
+ * Encoded body size in bytes (compressed / as transferred over the network).
  * Maps to: PerformanceResourceTiming.encodedBodySize
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_HTTP_RESPONSE_BODY_SIZE = 'http.response.body.size';
-export const ATTR_RESOURCE_ENCODED_BODY_SIZE = ATTR_HTTP_RESPONSE_BODY_SIZE;
+export const ATTR_HTTP_RESPONSE_BODY_ENCODED_SIZE =
+  'http.response.body.encoded_size';
+export const ATTR_RESOURCE_ENCODED_BODY_SIZE =
+  ATTR_HTTP_RESPONSE_BODY_ENCODED_SIZE;
 
 /**
- * Decoded body size in bytes (uncompressed).
+ * Decoded body size in bytes (uncompressed / after content decoding).
  * Maps to: PerformanceResourceTiming.decodedBodySize
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_RESOURCE_DECODED_BODY_SIZE =
+export const ATTR_HTTP_RESPONSE_BODY_DECODED_SIZE =
   'http.response.body.decoded_size';
+export const ATTR_RESOURCE_DECODED_BODY_SIZE =
+  ATTR_HTTP_RESPONSE_BODY_DECODED_SIZE;
 
 // ---------------------------------------------------------------------------
 // Resource metadata attributes

--- a/packages/instrumentation/src/resource-timing/semconv.ts
+++ b/packages/instrumentation/src/resource-timing/semconv.ts
@@ -236,6 +236,15 @@ export const ATTR_NETWORK_PROTOCOL_VERSION = 'network.protocol.version';
 export const ATTR_RESOURCE_INITIATOR_TYPE = 'browser.resource.initiator_type';
 
 /**
+ * HTTP response status code.
+ * Maps to: PerformanceResourceTiming.responseStatus
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HTTP_RESPONSE_STATUS_CODE = 'http.response.status_code';
+export const ATTR_RESOURCE_RESPONSE_STATUS = ATTR_HTTP_RESPONSE_STATUS_CODE;
+
+/**
  * Content type of the response.
  * Maps to: PerformanceResourceTiming.contentType
  *
@@ -243,7 +252,8 @@ export const ATTR_RESOURCE_INITIATOR_TYPE = 'browser.resource.initiator_type';
  */
 export const ATTR_HTTP_RESPONSE_HEADER_CONTENT_TYPE =
   'http.response.header.content-type';
-export const ATTR_RESOURCE_CONTENT_TYPE = ATTR_HTTP_RESPONSE_HEADER_CONTENT_TYPE;
+export const ATTR_RESOURCE_CONTENT_TYPE =
+  ATTR_HTTP_RESPONSE_HEADER_CONTENT_TYPE;
 
 /**
  * Render blocking status (blocking, non-blocking).


### PR DESCRIPTION
This is a **draft PR** to demonstrate how the unified HTTP client network timing conventions from [semantic-conventions#3385](https://github.com/open-telemetry/semantic-conventions/issues/3385) would look when applied to the resource timing instrumentation. The goal is to provide a concrete implementation to inform discussion.

  ### Changes

  - **Event name**: `browser.resource.timing` → `browser.resource_timing`
  - **Timing attributes**: Moved from `browser.resource.*` to `http.*` namespace (e.g., `http.call.start_time`, `http.dns.start_time`, `http.connect.start_time`)
  - **Delta time model**: `http.call.start_time` is absolute (ms since epoch); all other timing attributes are deltas from it. Browser API values of 0 (phase did not occur) are omitted.
  - **Protocol parsing**: `nextHopProtocol` split into `network.protocol.name` + `network.protocol.version`
  - **New attributes**: `http.response.status_code`, `http.response.header.content-type`, `http.response.body.encoded_size`, `http.response.body.decoded_size`
  - **Reuses existing semconv attributes** where available: `url.full`, `http.response.status_code`, `http.response.size`, `network.protocol.name`, `network.protocol.version`

  ### Attribute mapping

  | Browser API field | Attribute | Notes |
  |---|---|---|
  | `fetchStart` | `http.call.start_time` | Absolute timestamp (ms since epoch) |
  | `responseEnd` | `http.call.end_time` | Delta from start_time |
  | `duration` | `http.call.duration` | Total duration (ms) |
  | `redirectStart/End` | `http.redirect.start_time/end_time` | Omit if 0 |
  | `domainLookupStart/End` | `http.dns.start_time/end_time` | Omit if 0 |
  | `connectStart/End` | `http.connect.start_time/end_time` | Omit if 0 |
  | `secureConnectionStart` | `http.secure_connect.start_time` | Omit if 0 |
  | `requestStart` | `http.request.headers.start_time` | Omit if 0 |
  | `responseStart` | `http.response.headers.start_time` | Omit if 0 |
  | `workerStart` | `http.worker.start_time` | Omit if 0 |
  | `transferSize` | `http.response.size` | |
  | `encodedBodySize` | `http.response.body.encoded_size` | New; see semconv#3406 |
  | `decodedBodySize` | `http.response.body.decoded_size` | New; see semconv#3406 |
  | `responseStatus` | `http.response.status_code` | Omit if 0 |
  | `contentType` | `http.response.header.content-type` | |
  | `name` | `url.full` | |
  | `nextHopProtocol` | `network.protocol.name` + `.version` | Parsed |
  | `initiatorType` | `browser.resource.initiator_type` | Browser-specific |
  | `renderBlockingStatus` | `browser.resource.render_blocking_status` | Chromium only |

Here is what user would see in the browser dev console when debugging:

<img width="544" height="376" alt="image" src="https://github.com/user-attachments/assets/eea179d8-6afc-4a54-8fca-87f4c63b343c" />

And this corresponds to this resource timing object:

<img width="487" height="385" alt="image" src="https://github.com/user-attachments/assets/f0c3e568-1906-4562-92e5-e5ed95d8ed98" />

  ### Open questions for discussion

  #### Key concerns — should we adopt the unified conventions for browser?

  - **Non-intuitive mapping**: The mapping between these unified attributes and the well-known PerformanceResourceTiming fields is not obvious. Developers familiar with the browser API will need to learn a new naming scheme.
  - **Relative timestamps differ from browser API**: The browser reports values relative to `timeOrigin`; this convention uses deltas relative to request start. Anyone cross-referencing DevTools with telemetry data will see different values for the same phase.
  - **Mixed absolute/relative is confusing**: `http.call.start_time` is ~1.7 trillion while `http.call.end_time` is ~100 — looks like a bug when eyeballing raw data.

  #### Follow-up items if we adopt the unified conventions

  - **DNS namespace**: `http.dns.start_time` vs `dns.start_time` — DNS is not HTTP-specific
  - **Redundant attributes**: `http.call.duration` and `http.call.end_time` are always identical
  - **`startTime` vs `fetchStart`**: `startTime` is the true beginning (includes redirects), `fetchStart` is after redirects. Which should `http.call.start_time` represent?
  - **`transferSize: 0` semantics**: Means cache hit — should it be sent as explicit signal or omitted?
  - **Body size ambiguity**: `http.response.body.size` is ambiguous (see [semconv#3406](https://github.com/open-telemetry/semantic-conventions/issues/3406)); this PR uses explicit `encoded_size` / `decoded_size` instead