### PR TITLE
feat: update navigation timing semconv to browser.navigation_timing namespace

### DIFF
--- a/packages/instrumentation/src/navigation-timing/semconv.ts
+++ b/packages/instrumentation/src/navigation-timing/semconv.ts
@@ -11,127 +11,150 @@
 
 export const NAVIGATION_TIMING_EVENT_NAME = 'browser.navigation_timing';
 
-/**
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_NAVIGATION_TYPE = 'navigation.type';
+// Navigation-specific attributes (from PerformanceNavigationTiming).
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_URL = 'navigation.url';
+export const ATTR_NAVIGATION_TYPE = 'browser.navigation_timing.type';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_DURATION = 'navigation.duration';
+export const ATTR_NAVIGATION_URL = 'url.full';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_DOM_COMPLETE = 'navigation.dom_complete';
+export const ATTR_NAVIGATION_DOM_COMPLETE =
+  'browser.navigation_timing.dom_complete';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_NAVIGATION_DOM_CONTENT_LOADED_EVENT_END =
-  'navigation.dom_content_loaded_event_end';
+  'browser.navigation_timing.dom_content_loaded_event_end';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_NAVIGATION_DOM_CONTENT_LOADED_EVENT_START =
-  'navigation.dom_content_loaded_event_start';
+  'browser.navigation_timing.dom_content_loaded_event_start';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_DOM_INTERACTIVE = 'navigation.dom_interactive';
+export const ATTR_NAVIGATION_DOM_INTERACTIVE =
+  'browser.navigation_timing.dom_interactive';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_LOAD_EVENT_END = 'navigation.load_event_end';
+export const ATTR_NAVIGATION_LOAD_EVENT_END =
+  'browser.navigation_timing.load_event_end';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_LOAD_EVENT_START = 'navigation.load_event_start';
+export const ATTR_NAVIGATION_LOAD_EVENT_START =
+  'browser.navigation_timing.load_event_start';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_REDIRECT_COUNT = 'navigation.redirect_count';
+export const ATTR_NAVIGATION_REDIRECT_COUNT =
+  'browser.navigation_timing.redirect_count';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_UNLOAD_EVENT_END = 'navigation.unload_event_end';
+export const ATTR_NAVIGATION_UNLOAD_EVENT_END =
+  'browser.navigation_timing.unload_event_end';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_NAVIGATION_UNLOAD_EVENT_START =
-  'navigation.unload_event_start';
+  'browser.navigation_timing.unload_event_start';
+
+// Shared timing attributes inherited from PerformanceResourceTiming.
+// PerformanceNavigationTiming extends PerformanceResourceTiming, so these
+// values mirror resource timing. TODO: extract to a shared module to avoid
+// duplication.
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_FETCH_START = 'navigation.fetch_start';
+export const ATTR_NAVIGATION_DURATION = 'browser.resource_timing.duration';
+
+/**
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_NAVIGATION_FETCH_START =
+  'browser.resource_timing.fetch_start';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_NAVIGATION_DOMAIN_LOOKUP_START =
-  'navigation.domain_lookup_start';
+  'browser.resource_timing.domain_lookup_start';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_DOMAIN_LOOKUP_END = 'navigation.domain_lookup_end';
+export const ATTR_NAVIGATION_DOMAIN_LOOKUP_END =
+  'browser.resource_timing.domain_lookup_end';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_CONNECT_START = 'navigation.connect_start';
+export const ATTR_NAVIGATION_CONNECT_START =
+  'browser.resource_timing.connect_start';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_CONNECT_END = 'navigation.connect_end';
+export const ATTR_NAVIGATION_CONNECT_END =
+  'browser.resource_timing.connect_end';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_NAVIGATION_SECURE_CONNECTION_START =
-  'navigation.secure_connection_start';
+  'browser.resource_timing.secure_connection_start';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_REQUEST_START = 'navigation.request_start';
+export const ATTR_NAVIGATION_REQUEST_START =
+  'browser.resource_timing.request_start';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_RESPONSE_START = 'navigation.response_start';
+export const ATTR_NAVIGATION_RESPONSE_START =
+  'browser.resource_timing.response_start';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_RESPONSE_END = 'navigation.response_end';
+export const ATTR_NAVIGATION_RESPONSE_END =
+  'browser.resource_timing.response_end';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_TRANSFER_SIZE = 'navigation.transfer_size';
+export const ATTR_NAVIGATION_TRANSFER_SIZE =
+  'browser.resource_timing.transfer_size';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_ENCODED_BODY_SIZE = 'navigation.encoded_body_size';
+export const ATTR_NAVIGATION_ENCODED_BODY_SIZE =
+  'browser.resource_timing.encoded_body_size';
 
 /**
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const ATTR_NAVIGATION_DECODED_BODY_SIZE = 'navigation.decoded_body_size';
+export const ATTR_NAVIGATION_DECODED_BODY_SIZE =
+  'browser.resource_timing.decoded_body_size';


### PR DESCRIPTION
## Summary
- Renames the `navigation.*` attribute namespace to `browser.navigation_timing.*` for navigation-specific attributes, aligning with the `browser.navigation.*` namespace used by the upstream browser navigation instrumentation and the `browser.resource_timing.*` namespace adopted for resource timing (#240).
- Reuses `browser.resource_timing.*` for attributes inherited from `PerformanceResourceTiming` (duration, fetch_start, domain_lookup_*, connect_*, secure_connection_start, request_start, response_*, transfer_size, encoded_body_size, decoded_body_size), since `PerformanceNavigationTiming extends PerformanceResourceTiming`.
- URL attribute moves to the stable `url.full` semconv.
- Event name (`browser.navigation_timing`) is unchanged.

Follow-up: extract the shared resource-timing attribute constants to a common module that both instrumentations can import (currently duplicated with a TODO comment).

## Test plan
- [x] `npx vitest run packages/instrumentation/src/navigation-timing/`
- [x] Build passes