### PR TITLE
feat(instrumentation): port browser-navigation into consolidated package

### DIFF
--- a/eslint.dist.config.js
+++ b/eslint.dist.config.js
@@ -35,4 +35,20 @@ export default [
       ],
     },
   },
+  // navigation intentionally uses the Navigation API (not widely available)
+  // behind an opt-in config flag, with a history-patching fallback.
+  {
+    files: ['packages/instrumentation/dist/navigation/**/*.js'],
+    rules: {
+      'baseline-js/use-baseline': [
+        'error',
+        {
+          available: 'widely',
+          includeWebApis: { preset: 'auto' },
+          includeJsBuiltins: { preset: 'auto' },
+          ignoreFeatures: ['navigation'],
+        },
+      ],
+    },
+  },
 ];

--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -13,6 +13,7 @@ npm install @opentelemetry/browser-instrumentation
 
 ## Instrumentations
 
+- [Navigation](#navigation) — automatic instrumentation for browser navigations (initial load and SPA route changes)
 - [Navigation Timing](#navigation-timing) — automatic instrumentation for navigation timing
 - [Resource Timing](#resource-timing) — automatic instrumentation for resource timing
 - [User Action](#user-action) — automatic instrumentation for user actions (clicks)
@@ -28,6 +29,7 @@ import {
   SimpleLogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { NavigationInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/navigation';
 import { NavigationTimingInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/navigation-timing';
 import { ResourceTimingInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/resource-timing';
 import { UserActionInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/user-action';
@@ -42,6 +44,7 @@ logs.setGlobalLoggerProvider(logProvider);
 
 registerInstrumentations({
   instrumentations: [
+    new NavigationInstrumentation(),
     new NavigationTimingInstrumentation(),
     new ResourceTimingInstrumentation(),
     new UserActionInstrumentation(),
@@ -49,6 +52,62 @@ registerInstrumentations({
   ],
 });
 ```
+
+---
+
+### Navigation
+
+```typescript
+import { NavigationInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/navigation';
+```
+
+Emits a `browser.navigation` event for the initial page load (hard navigation) and for subsequent in-page navigations (soft navigations), including `history.pushState`, `history.replaceState`, `popstate`, and hash changes. When enabled via config, the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API) is used in preference to patching `history`.
+
+#### Configuration
+
+```typescript
+import {
+  NavigationInstrumentation,
+  defaultSanitizeUrl,
+} from '@opentelemetry/browser-instrumentation/experimental/navigation';
+
+new NavigationInstrumentation({
+  // Use window.navigation (Navigation API) when available instead of
+  // patching history.pushState / history.replaceState. Default: false.
+  useNavigationApiIfAvailable: true,
+
+  // Rewrite the captured URL before it is emitted. Useful for stripping
+  // path segments, query parameters, or tokens that should not be exported.
+  sanitizeUrl: (url) => defaultSanitizeUrl(url),
+
+  // Mutate the log record before it is emitted (e.g. attach custom attributes).
+  applyCustomLogRecordData: (logRecord) => {
+    logRecord.attributes = {
+      ...logRecord.attributes,
+      'app.route.id': '...',
+    };
+  },
+});
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `useNavigationApiIfAvailable` | `boolean` | `false` | When `true`, subscribes to the Navigation API (`currententrychange`) instead of patching `history.pushState` / `history.replaceState`. Falls back to history patching when the Navigation API is unavailable. |
+| `sanitizeUrl` | `(url: string) => string` | — | Called before the URL is written to `url.full`. |
+| `applyCustomLogRecordData` | `(logRecord: LogRecord) => void` | — | Hook to modify log records before they are emitted. Errors thrown from this hook are caught and logged via the instrumentation diag logger. |
+
+`defaultSanitizeUrl` is exported for composition — it redacts `user:password@` credentials and a set of common sensitive query parameters (`api_key`, `token`, `password`, etc.).
+
+#### Captured Attributes
+
+Each `browser.navigation` event includes:
+
+| Attribute | Description |
+|-----------|-------------|
+| `url.full` | The destination URL (after `sanitizeUrl` if configured). |
+| `browser.navigation.same_document` | `true` for SPA route changes; `false` for full-page loads. |
+| `browser.navigation.hash_change` | `true` when the navigation only adds or changes the URL fragment. |
+| `browser.navigation.type` | One of `push`, `replace`, `reload`, `traverse` (omitted for the initial hard navigation). |
 
 ---
 

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -10,7 +10,8 @@
     "navigation-timing",
     "user-action",
     "web-vitals",
-    "resource-timing"
+    "resource-timing",
+    "navigation"
   ],
   "homepage": "https://github.com/open-telemetry/opentelemetry-browser",
   "bugs": "https://github.com/open-telemetry/opentelemetry-browser/issues",
@@ -27,6 +28,7 @@
     "#instrumentation-test-utils": "./src/test-utils/index.ts"
   },
   "exports": {
+    "./experimental/navigation": "./dist/navigation/index.js",
     "./experimental/navigation-timing": "./dist/navigation-timing/index.js",
     "./experimental/user-action": "./dist/user-action/index.js",
     "./experimental/web-vitals": "./dist/web-vitals/index.js",

--- a/packages/instrumentation/src/navigation/index.ts
+++ b/packages/instrumentation/src/navigation/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { NavigationInstrumentation } from './instrumentation.ts';
+export type {
+  NavigationInstrumentationConfig,
+  NavigationType,
+} from './types.ts';
+export { defaultSanitizeUrl } from './utils.ts';

--- a/packages/instrumentation/src/navigation/instrumentation.test.ts
+++ b/packages/instrumentation/src/navigation/instrumentation.test.ts
@@ -1,0 +1,504 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { setupTestLogExporter } from '#instrumentation-test-utils';
+import { NavigationInstrumentation } from './instrumentation.ts';
+import {
+  ATTR_BROWSER_NAVIGATION_HASH_CHANGE,
+  ATTR_BROWSER_NAVIGATION_SAME_DOCUMENT,
+  ATTR_BROWSER_NAVIGATION_TYPE,
+  ATTR_URL_FULL,
+  BROWSER_NAVIGATION_EVENT_NAME,
+} from './semconv.ts';
+import { defaultSanitizeUrl } from './utils.ts';
+
+describe('NavigationInstrumentation', () => {
+  let inMemoryExporter: InMemoryLogRecordExporter;
+  let instrumentation: NavigationInstrumentation | undefined;
+  let restoreReadyState: (() => void) | undefined;
+
+  beforeAll(() => {
+    inMemoryExporter = setupTestLogExporter();
+  });
+
+  beforeEach(() => {
+    // Reset URL to a known state for each test so history-based assertions
+    // work regardless of previous tests.
+    window.history.replaceState({}, '', '/');
+  });
+
+  afterEach(() => {
+    instrumentation?.disable();
+    instrumentation = undefined;
+    inMemoryExporter.reset();
+    restoreReadyState?.();
+    restoreReadyState = undefined;
+  });
+
+  const getNavigationLogs = () =>
+    inMemoryExporter
+      .getFinishedLogRecords()
+      .filter((log) => log.eventName === BROWSER_NAVIGATION_EVENT_NAME);
+
+  const setReadyState = (state: DocumentReadyState) => {
+    const original = Object.getOwnPropertyDescriptor(document, 'readyState');
+    Object.defineProperty(document, 'readyState', {
+      value: state,
+      configurable: true,
+    });
+
+    restoreReadyState = () => {
+      if (original) {
+        Object.defineProperty(document, 'readyState', original);
+      } else {
+        delete (document as unknown as { readyState?: unknown }).readyState;
+      }
+    };
+  };
+
+  describe('lifecycle', () => {
+    it('should create an instance', () => {
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      expect(instrumentation).toBeInstanceOf(NavigationInstrumentation);
+    });
+
+    it('should enable and disable without errors', () => {
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      expect(() => {
+        instrumentation?.enable();
+        instrumentation?.disable();
+      }).not.toThrow();
+    });
+
+    it('should not double-subscribe when enabling twice', () => {
+      setReadyState('loading');
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      const addSpy = vi.spyOn(window, 'addEventListener');
+
+      instrumentation.enable();
+      instrumentation.enable();
+
+      const popstateCalls = addSpy.mock.calls.filter(
+        (c) => c[0] === 'popstate',
+      );
+      expect(popstateCalls).toHaveLength(1);
+
+      addSpy.mockRestore();
+    });
+  });
+
+  describe('hard navigation', () => {
+    it('should emit immediately when readyState is complete', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      instrumentation.enable();
+
+      const logs = getNavigationLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_SAME_DOCUMENT]).toBe(
+        false,
+      );
+      expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_HASH_CHANGE]).toBe(
+        false,
+      );
+    });
+
+    it('should emit on DOMContentLoaded when readyState is loading', () => {
+      setReadyState('loading');
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      instrumentation.enable();
+      expect(getNavigationLogs()).toHaveLength(0);
+
+      document.dispatchEvent(new Event('DOMContentLoaded'));
+
+      const logs = getNavigationLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_SAME_DOCUMENT]).toBe(
+        false,
+      );
+    });
+
+    it('should not emit a duplicate initial event if DOMContentLoaded fires twice', () => {
+      setReadyState('loading');
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      instrumentation.enable();
+
+      document.dispatchEvent(new Event('DOMContentLoaded'));
+      document.dispatchEvent(new Event('DOMContentLoaded'));
+
+      expect(getNavigationLogs()).toHaveLength(1);
+    });
+  });
+
+  describe('history API patching', () => {
+    it('should emit a push event when history.pushState is called', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      instrumentation.enable();
+      inMemoryExporter.reset();
+
+      window.history.pushState({}, '', '/new-path');
+
+      const logs = getNavigationLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_TYPE]).toBe('push');
+      expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_SAME_DOCUMENT]).toBe(
+        true,
+      );
+      expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_HASH_CHANGE]).toBe(
+        false,
+      );
+    });
+
+    it('should emit a replace event when history.replaceState is called', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      instrumentation.enable();
+      inMemoryExporter.reset();
+
+      window.history.replaceState({}, '', '/replaced');
+
+      const logs = getNavigationLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_TYPE]).toBe('replace');
+    });
+
+    it('should not emit when pushState is called twice with the same URL', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      instrumentation.enable();
+      inMemoryExporter.reset();
+
+      window.history.pushState({}, '', '/same');
+      expect(getNavigationLogs()).toHaveLength(1);
+
+      window.history.pushState({}, '', '/same');
+      expect(getNavigationLogs()).toHaveLength(1);
+    });
+
+    it('should still call the original pushState', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      instrumentation.enable();
+
+      window.history.pushState({ foo: 'bar' }, '', '/original-ran');
+
+      expect(window.location.pathname).toBe('/original-ran');
+      expect(window.history.state).toEqual({ foo: 'bar' });
+    });
+  });
+
+  describe('popstate', () => {
+    it('should emit a traverse event on popstate', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      instrumentation.enable();
+
+      // Advance URL so the plugin's tracked lastUrl is /page-a.
+      window.history.pushState({}, '', '/page-a');
+
+      // Simulate the browser going back: URL flips before popstate fires.
+      // Disable the plugin around the URL change so lastUrl stays at /page-a.
+      instrumentation.disable();
+      window.history.replaceState({}, '', '/');
+      instrumentation.enable();
+      inMemoryExporter.reset();
+
+      window.dispatchEvent(new PopStateEvent('popstate'));
+
+      const logs = getNavigationLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_TYPE]).toBe(
+        'traverse',
+      );
+    });
+  });
+
+  describe('hash change', () => {
+    it('should mark hash_change=true when only hash is added', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      instrumentation.enable();
+      inMemoryExporter.reset();
+
+      window.history.pushState({}, '', '/#section1');
+
+      const logs = getNavigationLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_HASH_CHANGE]).toBe(
+        true,
+      );
+    });
+
+    it('should mark hash_change=false when path changes', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      instrumentation.enable();
+      inMemoryExporter.reset();
+
+      window.history.pushState({}, '', '/new-path');
+
+      const logs = getNavigationLogs();
+      expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_HASH_CHANGE]).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('disable', () => {
+    it('should not emit for history changes after disable', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      instrumentation.enable();
+      inMemoryExporter.reset();
+      instrumentation.disable();
+
+      window.history.pushState({}, '', '/after-disable');
+
+      expect(getNavigationLogs()).toHaveLength(0);
+    });
+
+    it('should not emit on popstate after disable', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      instrumentation.enable();
+      inMemoryExporter.reset();
+      instrumentation.disable();
+
+      window.dispatchEvent(new PopStateEvent('popstate'));
+
+      expect(getNavigationLogs()).toHaveLength(0);
+    });
+  });
+
+  describe('sanitizeUrl', () => {
+    it('should not sanitize by default', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({ enabled: false });
+      instrumentation.enable();
+      inMemoryExporter.reset();
+
+      window.history.pushState({}, '', '/path?api_key=secret');
+
+      const logs = getNavigationLogs();
+      expect(logs[0]?.attributes[ATTR_URL_FULL]).toContain('api_key=secret');
+    });
+
+    it('should apply defaultSanitizeUrl when provided', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({
+        enabled: false,
+        sanitizeUrl: defaultSanitizeUrl,
+      });
+      instrumentation.enable();
+      inMemoryExporter.reset();
+
+      window.history.pushState({}, '', '/path?api_key=secret&normal=value');
+
+      const logs = getNavigationLogs();
+      const url = logs[0]?.attributes[ATTR_URL_FULL] as string;
+      expect(url).toContain('api_key=REDACTED');
+      expect(url).toContain('normal=value');
+    });
+
+    it('should apply a custom sanitizeUrl function', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({
+        enabled: false,
+        sanitizeUrl: (url) => url.replace('secret', 'CUSTOM'),
+      });
+      instrumentation.enable();
+      inMemoryExporter.reset();
+
+      window.history.pushState({}, '', '/path?token=secret');
+
+      const logs = getNavigationLogs();
+      expect(logs[0]?.attributes[ATTR_URL_FULL]).toContain('token=CUSTOM');
+    });
+  });
+
+  describe('applyCustomLogRecordData', () => {
+    it('should invoke the hook and allow attribute mutations', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({
+        enabled: false,
+        applyCustomLogRecordData: (logRecord) => {
+          (logRecord.attributes as Record<string, unknown>)['custom.key'] =
+            'custom.value';
+        },
+      });
+      instrumentation.enable();
+
+      const logs = getNavigationLogs();
+      expect(logs[0]?.attributes['custom.key']).toBe('custom.value');
+    });
+
+    it('should catch errors thrown by the hook and still emit', () => {
+      setReadyState('complete');
+      instrumentation = new NavigationInstrumentation({
+        enabled: false,
+        applyCustomLogRecordData: () => {
+          throw new Error('hook boom');
+        },
+      });
+      const diagErrorSpy = vi
+        .spyOn(
+          (
+            instrumentation as unknown as {
+              _diag: { error: (...a: unknown[]) => void };
+            }
+          )._diag,
+          'error',
+        )
+        .mockImplementation(() => {});
+
+      instrumentation.enable();
+
+      expect(getNavigationLogs()).toHaveLength(1);
+      expect(diagErrorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Navigation API', () => {
+    const installNavigationApi = (stub: EventTarget) => {
+      const original = Object.getOwnPropertyDescriptor(window, 'navigation');
+      Object.defineProperty(window, 'navigation', {
+        value: stub,
+        configurable: true,
+        writable: true,
+      });
+      return () => {
+        if (original) {
+          Object.defineProperty(window, 'navigation', original);
+        } else {
+          delete (window as unknown as { navigation?: unknown }).navigation;
+        }
+      };
+    };
+
+    it('should not patch history.pushState when Navigation API is used', () => {
+      setReadyState('complete');
+      const stub = new EventTarget();
+      const restore = installNavigationApi(stub);
+      const origPushState = window.history.pushState;
+
+      instrumentation = new NavigationInstrumentation({
+        enabled: false,
+        useNavigationApiIfAvailable: true,
+      });
+      instrumentation.enable();
+
+      expect(window.history.pushState).toBe(origPushState);
+      restore();
+    });
+
+    it('should emit when Navigation API currententrychange fires', () => {
+      setReadyState('complete');
+      const stub = new EventTarget() as EventTarget & {
+        currentEntry: { url: string };
+      };
+      stub.currentEntry = { url: 'http://localhost/nav-api-path' };
+      const restore = installNavigationApi(stub);
+
+      instrumentation = new NavigationInstrumentation({
+        enabled: false,
+        useNavigationApiIfAvailable: true,
+      });
+      instrumentation.enable();
+      inMemoryExporter.reset();
+
+      const event = new Event('currententrychange') as Event & {
+        navigationType?: string;
+      };
+      event.navigationType = 'push';
+      stub.dispatchEvent(event);
+
+      const logs = getNavigationLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes[ATTR_URL_FULL]).toBe(
+        'http://localhost/nav-api-path',
+      );
+      expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_TYPE]).toBe('push');
+
+      restore();
+    });
+
+    it('should fall back to history patching when window.navigation is undefined', () => {
+      setReadyState('complete');
+      // Ensure navigation is NOT defined (jsdom default)
+      expect(
+        (window as unknown as { navigation?: unknown }).navigation,
+      ).toBeUndefined();
+
+      instrumentation = new NavigationInstrumentation({
+        enabled: false,
+        useNavigationApiIfAvailable: true,
+      });
+      instrumentation.enable();
+      inMemoryExporter.reset();
+
+      window.history.pushState({}, '', '/fallback');
+
+      const logs = getNavigationLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_TYPE]).toBe('push');
+    });
+
+    it('should map currententrychange navigationType values correctly', () => {
+      setReadyState('complete');
+      const stub = new EventTarget() as EventTarget & {
+        currentEntry: { url: string };
+      };
+      stub.currentEntry = { url: 'http://localhost/nav-api-traverse' };
+      const restore = installNavigationApi(stub);
+
+      instrumentation = new NavigationInstrumentation({
+        enabled: false,
+        useNavigationApiIfAvailable: true,
+      });
+      instrumentation.enable();
+      inMemoryExporter.reset();
+
+      const event = new Event('currententrychange') as Event & {
+        navigationType?: string;
+      };
+      event.navigationType = 'traverse';
+      stub.dispatchEvent(event);
+
+      const logs = getNavigationLogs();
+      expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_TYPE]).toBe(
+        'traverse',
+      );
+
+      restore();
+    });
+  });
+
+  describe('multi-instance', () => {
+    it('should not throw when two instances are enabled and disabled', () => {
+      setReadyState('complete');
+      const a = new NavigationInstrumentation({ enabled: false });
+      const b = new NavigationInstrumentation({ enabled: false });
+
+      expect(() => {
+        a.enable();
+        b.enable();
+        window.history.pushState({}, '', '/dual');
+        a.disable();
+        b.disable();
+      }).not.toThrow();
+    });
+  });
+});

--- a/packages/instrumentation/src/navigation/instrumentation.ts
+++ b/packages/instrumentation/src/navigation/instrumentation.ts
@@ -66,11 +66,7 @@ export class NavigationInstrumentation extends InstrumentationBase<NavigationIns
   private declare _onCurrentEntryChange?: (event: NavigationApiEvent) => void;
 
   constructor(config: NavigationInstrumentationConfig = {}) {
-    super(
-      '@opentelemetry/browser-instrumentation/navigation',
-      version,
-      config,
-    );
+    super('@opentelemetry/browser-instrumentation/navigation', version, config);
     this._lastUrl = location.href;
   }
 
@@ -144,9 +140,7 @@ export class NavigationInstrumentation extends InstrumentationBase<NavigationIns
     if (!cfg.useNavigationApiIfAvailable) {
       return undefined;
     }
-    const nav = (window as unknown as { navigation?: NavigationApi })
-      .navigation;
-    return nav;
+    return (window as unknown as { navigation?: NavigationApi }).navigation;
   }
 
   private _onHardNavigation(): void {

--- a/packages/instrumentation/src/navigation/instrumentation.ts
+++ b/packages/instrumentation/src/navigation/instrumentation.ts
@@ -1,0 +1,311 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { LogRecord } from '@opentelemetry/api-logs';
+import { SeverityNumber } from '@opentelemetry/api-logs';
+import {
+  InstrumentationBase,
+  safeExecuteInTheMiddle,
+} from '@opentelemetry/instrumentation';
+import { version } from '../../package.json' with { type: 'json' };
+import {
+  ATTR_BROWSER_NAVIGATION_HASH_CHANGE,
+  ATTR_BROWSER_NAVIGATION_SAME_DOCUMENT,
+  ATTR_BROWSER_NAVIGATION_TYPE,
+  ATTR_URL_FULL,
+  BROWSER_NAVIGATION_EVENT_NAME,
+} from './semconv.ts';
+import type {
+  NavigationInstrumentationConfig,
+  NavigationType,
+} from './types.ts';
+import { isHashChange } from './utils.ts';
+
+type ChangeState =
+  | 'pushState'
+  | 'replaceState'
+  | 'popstate'
+  | 'currententrychange';
+
+interface NavigationApiEntry {
+  url?: string;
+}
+
+interface NavigationApiTarget {
+  currentEntry?: NavigationApiEntry;
+}
+
+interface NavigationApiEvent extends Event {
+  navigationType?: NavigationType;
+  target: NavigationApiTarget & EventTarget;
+}
+
+interface NavigationApi {
+  addEventListener(
+    type: 'currententrychange',
+    listener: (event: NavigationApiEvent) => void,
+  ): void;
+  removeEventListener(
+    type: 'currententrychange',
+    listener: (event: NavigationApiEvent) => void,
+  ): void;
+}
+
+export class NavigationInstrumentation extends InstrumentationBase<NavigationInstrumentationConfig> {
+  // Use `declare` to prevent JS class field initializers from running after
+  // super(), which would reset values set by the enable() call that
+  // InstrumentationBase makes during its constructor.
+  private declare _isEnabled: boolean;
+  private declare _isHistoryPatched: boolean;
+  private declare _hasProcessedInitialLoad: boolean;
+  private declare _lastUrl: string;
+  private declare _onDOMContentLoaded?: () => void;
+  private declare _onPopState?: (event: PopStateEvent) => void;
+  private declare _onCurrentEntryChange?: (event: NavigationApiEvent) => void;
+
+  constructor(config: NavigationInstrumentationConfig = {}) {
+    super(
+      '@opentelemetry/browser-instrumentation/navigation',
+      version,
+      config,
+    );
+    this._lastUrl = location.href;
+  }
+
+  protected override init() {
+    return [];
+  }
+
+  override enable(): void {
+    if (this._isEnabled) {
+      return;
+    }
+    this._isEnabled = true;
+
+    const navigationApi = this._getNavigationApi();
+
+    // Only patch history API if Navigation API is not being used.
+    if (!navigationApi && !this._isHistoryPatched) {
+      this._patchHistoryApi();
+      this._isHistoryPatched = true;
+    }
+
+    this._waitForPageLoad();
+
+    if (navigationApi) {
+      this._onCurrentEntryChange = (event) => {
+        this._onSoftNavigation('currententrychange', event);
+      };
+      navigationApi.addEventListener(
+        'currententrychange',
+        this._onCurrentEntryChange,
+      );
+    } else {
+      this._onPopState = () => {
+        this._onSoftNavigation('popstate');
+      };
+      window.addEventListener('popstate', this._onPopState);
+    }
+  }
+
+  override disable(): void {
+    if (!this._isEnabled) {
+      return;
+    }
+    this._isEnabled = false;
+
+    if (this._onDOMContentLoaded) {
+      document.removeEventListener(
+        'DOMContentLoaded',
+        this._onDOMContentLoaded,
+      );
+      this._onDOMContentLoaded = undefined;
+    }
+    if (this._onPopState) {
+      window.removeEventListener('popstate', this._onPopState);
+      this._onPopState = undefined;
+    }
+    if (this._onCurrentEntryChange) {
+      const navigationApi = this._getNavigationApi();
+      navigationApi?.removeEventListener(
+        'currententrychange',
+        this._onCurrentEntryChange,
+      );
+      this._onCurrentEntryChange = undefined;
+    }
+    // Reset the initial-load flag so it can be processed again if re-enabled.
+    this._hasProcessedInitialLoad = false;
+  }
+
+  private _getNavigationApi(): NavigationApi | undefined {
+    const cfg = this.getConfig();
+    if (!cfg.useNavigationApiIfAvailable) {
+      return undefined;
+    }
+    const nav = (window as unknown as { navigation?: NavigationApi })
+      .navigation;
+    return nav;
+  }
+
+  private _onHardNavigation(): void {
+    const cfg = this.getConfig();
+    const logRecord: LogRecord = {
+      eventName: BROWSER_NAVIGATION_EVENT_NAME,
+      severityNumber: SeverityNumber.INFO,
+      attributes: {
+        [ATTR_URL_FULL]: cfg.sanitizeUrl
+          ? cfg.sanitizeUrl(document.documentURI)
+          : document.documentURI,
+        [ATTR_BROWSER_NAVIGATION_SAME_DOCUMENT]: false,
+        [ATTR_BROWSER_NAVIGATION_HASH_CHANGE]: false,
+      },
+    };
+    this._applyCustomLogRecordData(logRecord);
+    this.logger.emit(logRecord);
+  }
+
+  private _onSoftNavigation(
+    changeState: ChangeState,
+    navigationEvent?: NavigationApiEvent,
+  ): void {
+    const referrerUrl = this._lastUrl;
+    const currentUrl =
+      changeState === 'currententrychange' &&
+      navigationEvent?.target?.currentEntry?.url
+        ? navigationEvent.target.currentEntry.url
+        : location.href;
+
+    if (referrerUrl === currentUrl) {
+      return;
+    }
+
+    const navType = this._mapChangeStateToType(changeState, navigationEvent);
+    const sameDocument = this._determineSameDocument(referrerUrl, currentUrl);
+    const hashChange = isHashChange(referrerUrl, currentUrl);
+    const cfg = this.getConfig();
+
+    const logRecord: LogRecord = {
+      eventName: BROWSER_NAVIGATION_EVENT_NAME,
+      severityNumber: SeverityNumber.INFO,
+      attributes: {
+        [ATTR_URL_FULL]: cfg.sanitizeUrl
+          ? cfg.sanitizeUrl(currentUrl)
+          : currentUrl,
+        [ATTR_BROWSER_NAVIGATION_SAME_DOCUMENT]: sameDocument,
+        [ATTR_BROWSER_NAVIGATION_HASH_CHANGE]: hashChange,
+        ...(navType ? { [ATTR_BROWSER_NAVIGATION_TYPE]: navType } : {}),
+      },
+    };
+    this._applyCustomLogRecordData(logRecord);
+    this.logger.emit(logRecord);
+
+    this._lastUrl = currentUrl;
+  }
+
+  private _waitForPageLoad(): void {
+    if (document.readyState === 'complete' && !this._hasProcessedInitialLoad) {
+      this._hasProcessedInitialLoad = true;
+      this._onHardNavigation();
+      return;
+    }
+
+    this._onDOMContentLoaded = () => {
+      if (!this._hasProcessedInitialLoad) {
+        this._hasProcessedInitialLoad = true;
+        this._onHardNavigation();
+      }
+    };
+    document.addEventListener('DOMContentLoaded', this._onDOMContentLoaded);
+  }
+
+  private _patchHistoryApi(): void {
+    this._wrap(
+      history,
+      'replaceState',
+      this._patchHistoryMethod('replaceState'),
+    );
+    this._wrap(history, 'pushState', this._patchHistoryMethod('pushState'));
+  }
+
+  private _patchHistoryMethod(changeState: 'pushState' | 'replaceState') {
+    const plugin = this;
+    return (original: History['pushState' | 'replaceState']) => {
+      return function patchedHistoryMethod(
+        this: History,
+        ...args: Parameters<History['pushState' | 'replaceState']>
+      ) {
+        if (!plugin._isEnabled) {
+          return original.apply(this, args);
+        }
+        const result = original.apply(this, args);
+        if (location.href !== plugin._lastUrl) {
+          plugin._onSoftNavigation(changeState);
+        }
+        return result;
+      };
+    };
+  }
+
+  private _applyCustomLogRecordData(logRecord: LogRecord): void {
+    const cfg = this.getConfig();
+    const hook = cfg.applyCustomLogRecordData;
+    if (!hook) {
+      return;
+    }
+    safeExecuteInTheMiddle(
+      () => hook(logRecord),
+      (error) => {
+        if (error) {
+          this._diag.error('applyCustomLogRecordData hook failed', error);
+        }
+      },
+      true,
+    );
+  }
+
+  private _determineSameDocument(fromUrl: string, toUrl: string): boolean {
+    try {
+      const fromURL = new URL(fromUrl);
+      const toURL = new URL(toUrl);
+      return fromURL.origin === toURL.origin;
+    } catch {
+      // Fallback: assume same document for relative URLs or parsing errors.
+      // In SPAs, route changes via pushState/replaceState are same-document.
+      return true;
+    }
+  }
+
+  private _mapChangeStateToType(
+    changeState: ChangeState,
+    navigationEvent?: NavigationApiEvent,
+  ): NavigationType | undefined {
+    if (changeState === 'currententrychange') {
+      const navType = navigationEvent?.navigationType;
+      switch (navType) {
+        case 'traverse':
+          return 'traverse';
+        case 'replace':
+          return 'replace';
+        case 'reload':
+          return 'reload';
+        default:
+          // Default to 'push' for programmatic navigations (history.pushState,
+          // link clicks) when no explicit type info is available.
+          return 'push';
+      }
+    }
+
+    switch (changeState) {
+      case 'pushState':
+        return 'push';
+      case 'replaceState':
+        return 'replace';
+      case 'popstate':
+        return 'traverse';
+      default:
+        return undefined;
+    }
+  }
+}

--- a/packages/instrumentation/src/navigation/semconv.ts
+++ b/packages/instrumentation/src/navigation/semconv.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This file contains a copy of unstable semantic convention definitions
+ * used by this package.
+ * @see https://github.com/open-telemetry/opentelemetry-js/tree/main/semantic-conventions#unstable-semconv
+ */
+
+export const BROWSER_NAVIGATION_EVENT_NAME = 'browser.navigation';
+
+/**
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_URL_FULL = 'url.full';
+
+/**
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_BROWSER_NAVIGATION_SAME_DOCUMENT =
+  'browser.navigation.same_document';
+
+/**
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_BROWSER_NAVIGATION_HASH_CHANGE =
+  'browser.navigation.hash_change';
+
+/**
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_BROWSER_NAVIGATION_TYPE = 'browser.navigation.type';

--- a/packages/instrumentation/src/navigation/types.ts
+++ b/packages/instrumentation/src/navigation/types.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { LogRecord } from '@opentelemetry/api-logs';
+import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
+
+export interface ApplyCustomLogRecordDataFunction {
+  (logRecord: LogRecord): void;
+}
+
+export interface SanitizeUrlFunction {
+  (url: string): string;
+}
+
+export type NavigationType = 'push' | 'replace' | 'reload' | 'traverse';
+
+/**
+ * NavigationInstrumentation Configuration
+ */
+export interface NavigationInstrumentationConfig extends InstrumentationConfig {
+  /** Hook to modify log records before they are emitted. */
+  applyCustomLogRecordData?: ApplyCustomLogRecordDataFunction;
+  /** Use the Navigation API `currententrychange` event if available (experimental). Defaults to false. */
+  useNavigationApiIfAvailable?: boolean;
+  /** Custom function to sanitize URLs before adding to log records. */
+  sanitizeUrl?: SanitizeUrlFunction;
+}

--- a/packages/instrumentation/src/navigation/types.ts
+++ b/packages/instrumentation/src/navigation/types.ts
@@ -6,13 +6,9 @@
 import type { LogRecord } from '@opentelemetry/api-logs';
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
-export interface ApplyCustomLogRecordDataFunction {
-  (logRecord: LogRecord): void;
-}
+export type ApplyCustomLogRecordDataFunction = (logRecord: LogRecord) => void;
 
-export interface SanitizeUrlFunction {
-  (url: string): string;
-}
+export type SanitizeUrlFunction = (url: string) => string;
 
 export type NavigationType = 'push' | 'replace' | 'reload' | 'traverse';
 

--- a/packages/instrumentation/src/navigation/utils.test.ts
+++ b/packages/instrumentation/src/navigation/utils.test.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { defaultSanitizeUrl, isHashChange } from './utils.ts';
+
+describe('isHashChange', () => {
+  it('should return true when adding a hash to the same URL', () => {
+    expect(
+      isHashChange('https://example.com/page', 'https://example.com/page#s1'),
+    ).toBe(true);
+  });
+
+  it('should return true when changing hash on the same URL', () => {
+    expect(
+      isHashChange(
+        'https://example.com/page#s1',
+        'https://example.com/page#s2',
+      ),
+    ).toBe(true);
+  });
+
+  it('should return false when removing a hash', () => {
+    expect(
+      isHashChange('https://example.com/page#s1', 'https://example.com/page'),
+    ).toBe(false);
+  });
+
+  it('should return false when URLs have different paths', () => {
+    expect(
+      isHashChange(
+        'https://example.com/page1#s1',
+        'https://example.com/page2#s1',
+      ),
+    ).toBe(false);
+  });
+
+  it('should return false when URLs have different origins', () => {
+    expect(
+      isHashChange(
+        'https://example.com/page#s1',
+        'https://other.com/page#s2',
+      ),
+    ).toBe(false);
+  });
+
+  it('should return false when URLs have different query parameters', () => {
+    expect(
+      isHashChange(
+        'https://example.com/page?p=1#s1',
+        'https://example.com/page?p=2#s2',
+      ),
+    ).toBe(false);
+  });
+
+  it('should return true when only hash differs with same query parameters', () => {
+    expect(
+      isHashChange(
+        'https://example.com/page?p=1#s1',
+        'https://example.com/page?p=1#s2',
+      ),
+    ).toBe(true);
+  });
+
+  it('should return true when adding hash with query parameters', () => {
+    expect(
+      isHashChange(
+        'https://example.com/page?p=1',
+        'https://example.com/page?p=1#s1',
+      ),
+    ).toBe(true);
+  });
+
+  it('should return false when URLs are identical', () => {
+    expect(
+      isHashChange(
+        'https://example.com/page#s1',
+        'https://example.com/page#s1',
+      ),
+    ).toBe(false);
+  });
+
+  it('should return false when both URLs have no hash', () => {
+    expect(
+      isHashChange('https://example.com/page', 'https://example.com/page'),
+    ).toBe(false);
+  });
+
+  describe('fallback behavior with invalid URLs', () => {
+    it('should handle malformed URLs in fallback mode', () => {
+      expect(isHashChange('not-a-valid-url', 'not-a-valid-url#s1')).toBe(true);
+    });
+
+    it('should return false in fallback mode when removing hash', () => {
+      expect(isHashChange('invalid-url#s1', 'invalid-url')).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty hash correctly', () => {
+      expect(
+        isHashChange('https://example.com/page#', 'https://example.com/page#s1'),
+      ).toBe(true);
+    });
+
+    it('should handle URLs with ports', () => {
+      expect(
+        isHashChange(
+          'https://example.com:8080/page',
+          'https://example.com:8080/page#s1',
+        ),
+      ).toBe(true);
+    });
+
+    it('should handle URLs with different ports as different origins', () => {
+      expect(
+        isHashChange(
+          'https://example.com:8080/page#s1',
+          'https://example.com:9090/page#s2',
+        ),
+      ).toBe(false);
+    });
+
+    it('should handle complex query parameters', () => {
+      expect(
+        isHashChange(
+          'https://example.com/page?a=1&b=2&c=3',
+          'https://example.com/page?a=1&b=2&c=3#s1',
+        ),
+      ).toBe(true);
+    });
+  });
+});
+
+describe('defaultSanitizeUrl', () => {
+  it('should redact username and password from URL', () => {
+    expect(defaultSanitizeUrl('https://user:pass@example.com/path')).toBe(
+      'https://REDACTED:REDACTED@example.com/path',
+    );
+  });
+
+  it('should redact sensitive query parameters', () => {
+    const sanitized = defaultSanitizeUrl(
+      'https://example.com/path?api_key=secret123&normal=value',
+    );
+    expect(sanitized).toContain('api_key=REDACTED');
+    expect(sanitized).toContain('normal=value');
+  });
+
+  it('should handle multiple sensitive parameters', () => {
+    const sanitized = defaultSanitizeUrl(
+      'https://example.com/path?token=abc123&password=secret&normal=value',
+    );
+    expect(sanitized).toContain('token=REDACTED');
+    expect(sanitized).toContain('password=REDACTED');
+    expect(sanitized).toContain('normal=value');
+  });
+
+  it('should preserve fragment/hash in URL', () => {
+    const sanitized = defaultSanitizeUrl(
+      'https://example.com/path?api_key=secret#section1',
+    );
+    expect(sanitized).toContain('#section1');
+    expect(sanitized).toContain('api_key=REDACTED');
+  });
+
+  it('should handle invalid URLs with fallback logic', () => {
+    const sanitized = defaultSanitizeUrl(
+      'invalid://user:pass@example.com/path?api_key=secret123',
+    );
+    expect(sanitized).toContain('REDACTED:REDACTED');
+    expect(sanitized).toContain('api_key=REDACTED');
+  });
+
+  it('should return URL unchanged if no sensitive data', () => {
+    const url = 'https://example.com/path?normal=value&other=data';
+    expect(defaultSanitizeUrl(url)).toBe(url);
+  });
+
+  it('should handle URL encoded sensitive parameters', () => {
+    const sanitized = defaultSanitizeUrl(
+      'https://example.com/path?api%5Fkey=secret123',
+    );
+    expect(sanitized).toContain('REDACTED');
+  });
+});

--- a/packages/instrumentation/src/navigation/utils.test.ts
+++ b/packages/instrumentation/src/navigation/utils.test.ts
@@ -39,10 +39,7 @@ describe('isHashChange', () => {
 
   it('should return false when URLs have different origins', () => {
     expect(
-      isHashChange(
-        'https://example.com/page#s1',
-        'https://other.com/page#s2',
-      ),
+      isHashChange('https://example.com/page#s1', 'https://other.com/page#s2'),
     ).toBe(false);
   });
 
@@ -101,7 +98,10 @@ describe('isHashChange', () => {
   describe('edge cases', () => {
     it('should handle empty hash correctly', () => {
       expect(
-        isHashChange('https://example.com/page#', 'https://example.com/page#s1'),
+        isHashChange(
+          'https://example.com/page#',
+          'https://example.com/page#s1',
+        ),
       ).toBe(true);
     });
 

--- a/packages/instrumentation/src/navigation/utils.ts
+++ b/packages/instrumentation/src/navigation/utils.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const SENSITIVE_PARAMS = [
+  'password',
+  'passwd',
+  'secret',
+  'api_key',
+  'apikey',
+  'auth',
+  'authorization',
+  'token',
+  'access_token',
+  'refresh_token',
+  'jwt',
+  'session',
+  'sessionid',
+  'key',
+  'private_key',
+  'client_secret',
+  'client_id',
+  'signature',
+  'hash',
+];
+
+/**
+ * Default URL sanitization function that redacts credentials and sensitive query parameters.
+ * This is the default implementation used when no custom sanitizeUrl callback is provided.
+ *
+ * @param url - The URL to sanitize
+ * @returns The sanitized URL with credentials and sensitive parameters redacted
+ */
+export function defaultSanitizeUrl(url: string): string {
+  try {
+    const urlObj = new URL(url);
+
+    if (urlObj.username || urlObj.password) {
+      urlObj.username = 'REDACTED';
+      urlObj.password = 'REDACTED';
+    }
+
+    for (const param of SENSITIVE_PARAMS) {
+      if (urlObj.searchParams.has(param)) {
+        urlObj.searchParams.set(param, 'REDACTED');
+      }
+    }
+
+    return urlObj.toString();
+  } catch {
+    // If URL parsing fails, redact credentials and sensitive query parameters
+    // using regexes. The credential regex uses a restricted character class to
+    // avoid polynomial time complexity.
+    let sanitized = url.replace(/\/\/[^:/@]+:[^/@]+@/, '//REDACTED:REDACTED@');
+
+    for (const param of SENSITIVE_PARAMS) {
+      // Match param=value or param%3Dvalue (URL encoded)
+      const regex = new RegExp(`([?&]${param}(?:%3D|=))[^&]*`, 'gi');
+      sanitized = sanitized.replace(regex, '$1REDACTED');
+    }
+
+    return sanitized;
+  }
+}
+
+/**
+ * Determines if navigation between two URLs represents a hash change.
+ * A hash change is true if the URLs are the same except for the hash part,
+ * AND the hash is being added or changed (not removed).
+ *
+ * @param fromUrl - The source URL
+ * @param toUrl - The destination URL
+ * @returns true if this represents a hash change navigation
+ */
+export function isHashChange(fromUrl: string, toUrl: string): boolean {
+  try {
+    const a = new URL(fromUrl, window.location.origin);
+    const b = new URL(toUrl, window.location.origin);
+    const sameBase =
+      a.origin === b.origin &&
+      a.pathname === b.pathname &&
+      a.search === b.search;
+    const fromHasHash = a.hash !== '';
+    const toHasHash = b.hash !== '';
+    const hashesAreDifferent = a.hash !== b.hash;
+
+    return (
+      sameBase &&
+      hashesAreDifferent &&
+      ((fromHasHash && toHasHash) || (!fromHasHash && toHasHash))
+    );
+  } catch {
+    const fromBase = fromUrl.split('#')[0];
+    const toBase = toUrl.split('#')[0];
+    const fromHash = fromUrl.split('#')[1] ?? '';
+    const toHash = toUrl.split('#')[1] ?? '';
+
+    const sameBase = fromBase === toBase;
+    const hashesAreDifferent = fromHash !== toHash;
+    const notRemovingHash = toHash !== '';
+
+    return sameBase && hashesAreDifferent && notRemovingHash;
+  }
+}


### PR DESCRIPTION
## Summary

Ports `instrumentation-browser-navigation` from opentelemetry-js-contrib into `@opentelemetry/browser-instrumentation` under a new `./experimental/navigation` subpath. Addresses the first checklist item of #238 ("Move code to this repo"); deprecation/deletion of the contrib package is tracked as separate items in that issue.

Adapted to repo conventions: `InstrumentationBase` + `this.logger.emit()`, `declare` field pattern, `safeExecuteInTheMiddle` around the user hook, `verbatimModuleSyntax`-friendly imports, vitest tests via `setupTestLogExporter`.

## Test plan

- [x] `npm run check-types` — clean
- [x] `npm run build` — clean, including `attw` and `publint`
- [x] `npm test` — 119/119 passing (unit + browser projects)
- [x] Repo-root `turbo build` — successful, examples build picks up the new subpath export

Refs #238