### PR TITLE
fix(ci): use client-id for release-please app token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ vars.OTELBOT_BROWSER_APP_ID }}
+          client-id: ${{ vars.OTELBOT_BROWSER_APP_ID }}
           private-key: ${{ secrets.OTELBOT_BROWSER_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0


### PR DESCRIPTION
## Which problem is this PR solving?

The `actions/create-github-app-token` action expects a `client-id` input, not `app-id`. The workflow was passing the value through a deprecated input, leading to a warning.

## Short description of the changes

Rename the input from `app-id` to `client-id` in `.github/workflows/release-please.yml` so the GitHub App token is issued correctly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Verify the release-please workflow runs successfully on the next push to main

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated