### PR TITLE
feat: translate event_name from OTLP to event_name attribute in Loki

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.123.0
+    image: otel/opentelemetry-collector-contrib:0.128.0
     command: ["--config=/etc/otelcol-contrib/config.yaml"]
     volumes:
       - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml

--- a/demo/otel-collector-config.yaml
+++ b/demo/otel-collector-config.yaml
@@ -122,12 +122,20 @@ processors:
       - context: log
         statements:
           - set(attributes["scope.name"], instrumentation_scope.name)
+  # Loki's OTLP ingest does not map the top-level OTLP `event_name` field to a
+  # stream label or structured metadata. Mirror it into a log attribute so it
+  # surfaces as the `event_name` label in Loki.
+  transform/event_name_to_attr:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["event.name"], event_name) where event_name != nil and event_name != ""
 
 service:
   pipelines:
     logs:
       receivers: [otlp]
-      processors: [transform/copy_scope, batch]
+      processors: [transform/copy_scope, transform/event_name_to_attr, batch]
       exporters: [otlphttp/loki, count, signaltometrics]
     traces:
       receivers: [otlp]


### PR DESCRIPTION
This makes the event_name value available on logs in Loki.

- Update collector contrib to a version that reads the event_name field
- Add a transform that copies the event_name value into the event.name attribute