### PR TITLE
feat(instrumentation): port instrumentation-web-exception into consolidated package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7038,6 +7038,7 @@
       "dependencies": {
         "@opentelemetry/api-logs": "^0.216.0",
         "@opentelemetry/instrumentation": "^0.216.0",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
         "web-vitals": "^5.2.0"
       },
       "devDependencies": {

--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -19,6 +19,7 @@ npm install @opentelemetry/browser-instrumentation
 - [User Action](#user-action) — automatic instrumentation for user actions (clicks)
 - [Web Vitals](#web-vitals) — automatic instrumentation for Core Web Vitals
 - [Console](#console) — automatic instrumentation for console API calls (log, warn, error, info, debug)
+- [Exception](#exception) — automatic instrumentation for unhandled errors and promise rejections
 
 ## Usage
 
@@ -30,6 +31,7 @@ import {
   SimpleLogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { ExceptionInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/errors';
 import { NavigationInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/navigation';
 import { NavigationTimingInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/navigation-timing';
 import { ResourceTimingInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/resource-timing';
@@ -45,6 +47,7 @@ logs.setGlobalLoggerProvider(logProvider);
 
 registerInstrumentations({
   instrumentations: [
+    new ExceptionInstrumentation(),
     new NavigationInstrumentation(),
     new NavigationTimingInstrumentation(),
     new ResourceTimingInstrumentation(),
@@ -244,6 +247,44 @@ Each `browser.console` event includes the following attributes:
 | Attribute | Description | Example |
 |-----------|-------------|---------|
 | `browser.console.method` | The console method that was called | `error`, `warn`, `log`, `info`, `debug` |
+
+---
+
+### Exception
+
+```typescript
+import { ExceptionInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/errors';
+```
+
+Emits an `exception` event for every uncaught error (`window` `error` event) and unhandled promise rejection (`window` `unhandledrejection` event).
+
+#### Configuration
+
+```typescript
+new ExceptionInstrumentation({
+  // Return extra attributes to attach to the emitted log record.
+  applyCustomAttributes: (error) => ({
+    'app.error.severity':
+      error instanceof Error && error.name === 'ValidationError'
+        ? 'warning'
+        : 'error',
+  }),
+});
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `applyCustomAttributes` | `(error: Error \| string) => Attributes` | — | Returns extra attributes to merge onto the emitted log record. Errors thrown from this hook are caught and logged via the instrumentation diag logger. |
+
+#### Captured Attributes
+
+Each `exception` event includes:
+
+| Attribute | Description |
+|-----------|-------------|
+| `exception.type` | The error's `name` (omitted when the thrown value is a string). |
+| `exception.message` | The error's `message`, or the thrown string itself. |
+| `exception.stacktrace` | The error's `stack` (omitted when the thrown value is a string). |
 
 ## Useful links
 

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -12,7 +12,8 @@
     "user-action",
     "web-vitals",
     "resource-timing",
-    "navigation"
+    "navigation",
+    "errors"
   ],
   "homepage": "https://github.com/open-telemetry/opentelemetry-browser",
   "bugs": "https://github.com/open-telemetry/opentelemetry-browser/issues",
@@ -29,6 +30,7 @@
     "#utils/test": "./src/utils/test/index.ts"
   },
   "exports": {
+    "./experimental/errors": "./dist/errors/index.js",
     "./experimental/navigation": "./dist/navigation/index.js",
     "./experimental/console": "./dist/console/index.js",
     "./experimental/navigation-timing": "./dist/navigation-timing/index.js",
@@ -50,6 +52,7 @@
   "dependencies": {
     "@opentelemetry/api-logs": "^0.216.0",
     "@opentelemetry/instrumentation": "^0.216.0",
+    "@opentelemetry/semantic-conventions": "^1.40.0",
     "web-vitals": "^5.2.0"
   },
   "peerDependencies": {

--- a/packages/instrumentation/src/errors/index.ts
+++ b/packages/instrumentation/src/errors/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { ExceptionInstrumentation } from './instrumentation.ts';
+export type {
+  ApplyCustomAttributesFunction,
+  ExceptionInstrumentationConfig,
+} from './types.ts';

--- a/packages/instrumentation/src/errors/instrumentation.test.ts
+++ b/packages/instrumentation/src/errors/instrumentation.test.ts
@@ -1,0 +1,269 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
+import {
+  ATTR_EXCEPTION_MESSAGE,
+  ATTR_EXCEPTION_STACKTRACE,
+  ATTR_EXCEPTION_TYPE,
+} from '@opentelemetry/semantic-conventions';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { setupTestLogExporter } from '#utils/test';
+import { ExceptionInstrumentation } from './instrumentation.ts';
+
+const EXCEPTION_EVENT_NAME = 'exception';
+const STRING_ERROR = 'Some error string.';
+
+class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}
+
+// jsdom routes window 'error' events through its uncaught-exception reporter,
+// which would surface to vitest's unhandled error reporter and fail the run.
+// We dispatch a cancelable plain Event (the instrumentation only reads
+// `event.error`) and call preventDefault from a capture-phase listener to
+// suppress the default reporting behavior.
+const dispatchErrorEvent = (error?: Error | string) => {
+  const event = new Event('error', { cancelable: true });
+  if (error !== undefined) {
+    Object.defineProperty(event, 'error', { value: error });
+  }
+  const suppress = (e: Event) => e.preventDefault();
+  window.addEventListener('error', suppress, { capture: true });
+  try {
+    window.dispatchEvent(event);
+  } finally {
+    window.removeEventListener('error', suppress, { capture: true });
+  }
+};
+
+const dispatchUnhandledRejection = (reason: Error | string) => {
+  // jsdom does not implement the PromiseRejectionEvent constructor, so we
+  // synthesize an event with the same shape the instrumentation listens for.
+  const event = new Event('unhandledrejection');
+  Object.defineProperty(event, 'reason', { value: reason });
+  window.dispatchEvent(event);
+};
+
+describe('ExceptionInstrumentation', () => {
+  let inMemoryExporter: InMemoryLogRecordExporter;
+  let instrumentation: ExceptionInstrumentation | undefined;
+
+  beforeAll(() => {
+    inMemoryExporter = setupTestLogExporter();
+  });
+
+  beforeEach(() => {
+    inMemoryExporter.reset();
+  });
+
+  afterEach(() => {
+    instrumentation?.disable();
+    instrumentation = undefined;
+    inMemoryExporter.reset();
+  });
+
+  const getExceptionLogs = () =>
+    inMemoryExporter
+      .getFinishedLogRecords()
+      .filter((log) => log.eventName === EXCEPTION_EVENT_NAME);
+
+  describe('lifecycle', () => {
+    it('should create an instance', () => {
+      instrumentation = new ExceptionInstrumentation({ enabled: false });
+      expect(instrumentation).toBeInstanceOf(ExceptionInstrumentation);
+    });
+
+    it('should enable and disable without errors', () => {
+      instrumentation = new ExceptionInstrumentation({ enabled: false });
+      expect(() => {
+        instrumentation?.enable();
+        instrumentation?.disable();
+      }).not.toThrow();
+    });
+
+    it('should not emit after disable', () => {
+      instrumentation = new ExceptionInstrumentation({ enabled: false });
+      instrumentation.enable();
+      instrumentation.disable();
+
+      dispatchErrorEvent(new Error('after disable'));
+
+      expect(getExceptionLogs()).toHaveLength(0);
+    });
+
+    it('should not double-subscribe when enabling twice', () => {
+      instrumentation = new ExceptionInstrumentation({ enabled: false });
+      const addSpy = vi.spyOn(window, 'addEventListener');
+
+      instrumentation.enable();
+      instrumentation.enable();
+
+      const errorCalls = addSpy.mock.calls.filter((c) => c[0] === 'error');
+      const rejectionCalls = addSpy.mock.calls.filter(
+        (c) => c[0] === 'unhandledrejection',
+      );
+      expect(errorCalls).toHaveLength(1);
+      expect(rejectionCalls).toHaveLength(1);
+
+      addSpy.mockRestore();
+    });
+  });
+
+  describe('error events', () => {
+    beforeEach(() => {
+      instrumentation = new ExceptionInstrumentation({ enabled: false });
+      instrumentation.enable();
+    });
+
+    it('should emit an exception event when an Error is thrown', () => {
+      dispatchErrorEvent(new ValidationError('Something happened!'));
+
+      const logs = getExceptionLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.eventName).toBe(EXCEPTION_EVENT_NAME);
+    });
+
+    it('should set semantic attributes for Error objects', () => {
+      const stack =
+        'Error: Something happened\n' +
+        '    at baz (filename.js:10:15)\n' +
+        '    at bar (filename.js:6:3)\n' +
+        '    at foo (filename.js:2:3)';
+      const error = new ValidationError('Something happened!');
+      error.stack = stack;
+
+      dispatchErrorEvent(error);
+
+      const logs = getExceptionLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes[ATTR_EXCEPTION_TYPE]).toBe('ValidationError');
+      expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe(
+        'Something happened!',
+      );
+      expect(logs[0]?.attributes[ATTR_EXCEPTION_STACKTRACE]).toBe(stack);
+    });
+
+    it('should handle a string error', () => {
+      dispatchErrorEvent(STRING_ERROR);
+
+      const logs = getExceptionLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe(STRING_ERROR);
+      expect(logs[0]?.attributes[ATTR_EXCEPTION_TYPE]).toBeUndefined();
+      expect(logs[0]?.attributes[ATTR_EXCEPTION_STACKTRACE]).toBeUndefined();
+    });
+
+    it('should not emit when the error is missing', () => {
+      dispatchErrorEvent();
+
+      expect(getExceptionLogs()).toHaveLength(0);
+    });
+  });
+
+  describe('unhandled rejection events', () => {
+    beforeEach(() => {
+      instrumentation = new ExceptionInstrumentation({ enabled: false });
+      instrumentation.enable();
+    });
+
+    it('should emit an exception event when a promise is rejected with an Error', () => {
+      const error = new ValidationError('Rejected!');
+      dispatchUnhandledRejection(error);
+
+      const logs = getExceptionLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes[ATTR_EXCEPTION_TYPE]).toBe('ValidationError');
+      expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe('Rejected!');
+    });
+
+    it('should emit an exception event when a promise is rejected with a string', () => {
+      dispatchUnhandledRejection(STRING_ERROR);
+
+      const logs = getExceptionLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe(STRING_ERROR);
+      expect(logs[0]?.attributes[ATTR_EXCEPTION_TYPE]).toBeUndefined();
+    });
+  });
+
+  describe('applyCustomAttributes', () => {
+    it('should merge custom attributes for Error objects', () => {
+      instrumentation = new ExceptionInstrumentation({
+        enabled: false,
+        applyCustomAttributes: (error) => ({
+          'app.custom.exception':
+            error instanceof Error
+              ? error.message.toLocaleUpperCase()
+              : error.toLocaleUpperCase(),
+        }),
+      });
+      instrumentation.enable();
+
+      dispatchErrorEvent(new ValidationError('Something happened!'));
+
+      const logs = getExceptionLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes['app.custom.exception']).toBe(
+        'SOMETHING HAPPENED!',
+      );
+      expect(logs[0]?.attributes[ATTR_EXCEPTION_TYPE]).toBe('ValidationError');
+    });
+
+    it('should merge custom attributes for string errors', () => {
+      instrumentation = new ExceptionInstrumentation({
+        enabled: false,
+        applyCustomAttributes: (error) => ({
+          'app.custom.exception':
+            typeof error === 'string'
+              ? error.toLocaleUpperCase()
+              : error.message.toLocaleUpperCase(),
+        }),
+      });
+      instrumentation.enable();
+
+      dispatchErrorEvent(STRING_ERROR);
+
+      const logs = getExceptionLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe(STRING_ERROR);
+      expect(logs[0]?.attributes['app.custom.exception']).toBe(
+        STRING_ERROR.toLocaleUpperCase(),
+      );
+    });
+
+    it('should still emit standard attributes when the hook throws', () => {
+      instrumentation = new ExceptionInstrumentation({
+        enabled: false,
+        applyCustomAttributes: () => {
+          throw new Error('hook boom');
+        },
+      });
+      instrumentation.enable();
+
+      expect(() =>
+        dispatchErrorEvent(new ValidationError('Something happened!')),
+      ).not.toThrow();
+
+      const logs = getExceptionLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.attributes[ATTR_EXCEPTION_TYPE]).toBe('ValidationError');
+      expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe(
+        'Something happened!',
+      );
+    });
+  });
+});

--- a/packages/instrumentation/src/errors/instrumentation.ts
+++ b/packages/instrumentation/src/errors/instrumentation.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Attributes } from '@opentelemetry/api';
+import type { AnyValueMap, LogRecord } from '@opentelemetry/api-logs';
+import { SeverityNumber } from '@opentelemetry/api-logs';
+import {
+  InstrumentationBase,
+  safeExecuteInTheMiddle,
+} from '@opentelemetry/instrumentation';
+import {
+  ATTR_EXCEPTION_MESSAGE,
+  ATTR_EXCEPTION_STACKTRACE,
+  ATTR_EXCEPTION_TYPE,
+} from '@opentelemetry/semantic-conventions';
+import { version } from '../../package.json' with { type: 'json' };
+import type { ExceptionInstrumentationConfig } from './types.ts';
+
+const EXCEPTION_EVENT_NAME = 'exception';
+
+export class ExceptionInstrumentation extends InstrumentationBase<ExceptionInstrumentationConfig> {
+  // Use `declare` to prevent JS class field initializers from running after
+  // super(), which would reset values set by the enable() call that
+  // InstrumentationBase makes during its constructor.
+  private declare _isEnabled: boolean;
+  private declare _onErrorHandler?: (
+    event: ErrorEvent | PromiseRejectionEvent,
+  ) => void;
+
+  constructor(config: ExceptionInstrumentationConfig = {}) {
+    super('@opentelemetry/browser-instrumentation/errors', version, config);
+  }
+
+  protected override init() {
+    return [];
+  }
+
+  override enable(): void {
+    if (this._isEnabled) {
+      return;
+    }
+    this._isEnabled = true;
+
+    this._onErrorHandler = (event) => this._onError(event);
+    window.addEventListener('error', this._onErrorHandler);
+    window.addEventListener('unhandledrejection', this._onErrorHandler);
+  }
+
+  override disable(): void {
+    if (!this._isEnabled) {
+      return;
+    }
+    this._isEnabled = false;
+
+    if (this._onErrorHandler) {
+      window.removeEventListener('error', this._onErrorHandler);
+      window.removeEventListener('unhandledrejection', this._onErrorHandler);
+      this._onErrorHandler = undefined;
+    }
+  }
+
+  private _onError(event: ErrorEvent | PromiseRejectionEvent): void {
+    const error: Error | string | null | undefined =
+      'reason' in event ? event.reason : event.error;
+
+    if (error == null) {
+      return;
+    }
+
+    let errorAttributes: AnyValueMap;
+    if (typeof error === 'string') {
+      errorAttributes = { [ATTR_EXCEPTION_MESSAGE]: error };
+    } else {
+      errorAttributes = {
+        [ATTR_EXCEPTION_TYPE]: error.name,
+        [ATTR_EXCEPTION_MESSAGE]: error.message,
+        [ATTR_EXCEPTION_STACKTRACE]: error.stack,
+      };
+    }
+
+    const customAttributes = this._applyCustomAttributes(error);
+
+    const logRecord: LogRecord = {
+      eventName: EXCEPTION_EVENT_NAME,
+      severityNumber: SeverityNumber.ERROR,
+      attributes: { ...errorAttributes, ...customAttributes },
+    };
+
+    this.logger.emit(logRecord);
+  }
+
+  private _applyCustomAttributes(error: Error | string): Attributes {
+    const hook = this.getConfig().applyCustomAttributes;
+    if (!hook) {
+      return {};
+    }
+    let result: Attributes = {};
+    safeExecuteInTheMiddle(
+      () => {
+        result = hook(error);
+      },
+      (err) => {
+        if (err) {
+          this._diag.error('applyCustomAttributes hook failed', err);
+        }
+      },
+      true,
+    );
+    return result;
+  }
+}

--- a/packages/instrumentation/src/errors/types.ts
+++ b/packages/instrumentation/src/errors/types.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Attributes } from '@opentelemetry/api';
+import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
+
+export type ApplyCustomAttributesFunction = (
+  error: Error | string,
+) => Attributes;
+
+/**
+ * ExceptionInstrumentation Configuration
+ */
+export interface ExceptionInstrumentationConfig extends InstrumentationConfig {
+  /**
+   * Optional callback invoked for each captured error or unhandled rejection.
+   * Returned attributes are merged onto the emitted log record (after the
+   * standard `exception.*` attributes, so they may override them).
+   */
+  applyCustomAttributes?: ApplyCustomAttributesFunction;
+}


### PR DESCRIPTION
## Summary

Ports `instrumentation-web-exception` from opentelemetry-js-contrib into `@opentelemetry/browser-instrumentation` under a new `./experimental/errors` subpath. Addresses the first checklist item of #239 ("Move code to this repo"); deprecation/deletion of the contrib package is tracked as separate items in that issue.

Adapted to repo conventions: `InstrumentationBase` + `this.logger.emit()`, `declare` field pattern, `safeExecuteInTheMiddle` around the `applyCustomAttributes` user hook, idempotent enable/disable, semconv keys imported from `@opentelemetry/semantic-conventions`, vitest tests via `setupTestLogExporter`.

## Test plan

- [x] `npm run check-types` — clean
- [x] `npm run build` — clean, including `attw` and `publint`
- [x] `npm test` — 144/144 passing (unit project)
- [x] Repo-root `turbo build` — successful, examples build picks up the new subpath export
- [x] `eslint --config eslint.dist.config.js packages/instrumentation/dist` — clean (baseline web compat)

Refs #239