### PR TITLE
chore(instrumentation): rename ExceptionInstrumentation to ErrorsInstrumentation

### DIFF
--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -19,7 +19,7 @@ npm install @opentelemetry/browser-instrumentation
 - [User Action](#user-action) — automatic instrumentation for user actions (clicks)
 - [Web Vitals](#web-vitals) — automatic instrumentation for Core Web Vitals
 - [Console](#console) — automatic instrumentation for console API calls (log, warn, error, info, debug)
-- [Exception](#exception) — automatic instrumentation for unhandled errors and promise rejections
+- [Errors](#errors) — automatic instrumentation for unhandled errors and promise rejections
 
 ## Usage
 
@@ -31,7 +31,7 @@ import {
   SimpleLogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
-import { ExceptionInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/errors';
+import { ErrorsInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/errors';
 import { NavigationInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/navigation';
 import { NavigationTimingInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/navigation-timing';
 import { ResourceTimingInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/resource-timing';
@@ -47,7 +47,7 @@ logs.setGlobalLoggerProvider(logProvider);
 
 registerInstrumentations({
   instrumentations: [
-    new ExceptionInstrumentation(),
+    new ErrorsInstrumentation(),
     new NavigationInstrumentation(),
     new NavigationTimingInstrumentation(),
     new ResourceTimingInstrumentation(),
@@ -250,18 +250,18 @@ Each `browser.console` event includes the following attributes:
 
 ---
 
-### Exception
+### Errors
 
 ```typescript
-import { ExceptionInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/errors';
+import { ErrorsInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/errors';
 ```
 
-Emits an `exception` event for every uncaught error (`window` `error` event) and unhandled promise rejection (`window` `unhandledrejection` event).
+Emits an `exception` event for every uncaught error (`window.addEventListener('error', ...)`) and unhandled promise rejection (`window.addEventListener('unhandledrejection', ...)`).
 
 #### Configuration
 
 ```typescript
-new ExceptionInstrumentation({
+new ErrorsInstrumentation({
   // Return extra attributes to attach to the emitted log record.
   applyCustomAttributes: (error) => ({
     'app.error.severity':

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -8,12 +8,12 @@
     "web",
     "instrumentation",
     "console",
-    "navigation-timing",
-    "user-action",
-    "web-vitals",
-    "resource-timing",
+    "errors",
     "navigation",
-    "errors"
+    "navigation-timing",
+    "resource-timing",
+    "user-action",
+    "web-vitals"
   ],
   "homepage": "https://github.com/open-telemetry/opentelemetry-browser",
   "bugs": "https://github.com/open-telemetry/opentelemetry-browser/issues",
@@ -30,13 +30,13 @@
     "#utils/test": "./src/utils/test/index.ts"
   },
   "exports": {
+    "./experimental/console": "./dist/console/index.js",
     "./experimental/errors": "./dist/errors/index.js",
     "./experimental/navigation": "./dist/navigation/index.js",
-    "./experimental/console": "./dist/console/index.js",
     "./experimental/navigation-timing": "./dist/navigation-timing/index.js",
+    "./experimental/resource-timing": "./dist/resource-timing/index.js",
     "./experimental/user-action": "./dist/user-action/index.js",
-    "./experimental/web-vitals": "./dist/web-vitals/index.js",
-    "./experimental/resource-timing": "./dist/resource-timing/index.js"
+    "./experimental/web-vitals": "./dist/web-vitals/index.js"
   },
   "files": [
     "dist"

--- a/packages/instrumentation/src/errors/index.ts
+++ b/packages/instrumentation/src/errors/index.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { ExceptionInstrumentation } from './instrumentation.ts';
+export { ErrorsInstrumentation } from './instrumentation.ts';
 export type {
   ApplyCustomAttributesFunction,
-  ExceptionInstrumentationConfig,
+  ErrorsInstrumentationConfig,
 } from './types.ts';

--- a/packages/instrumentation/src/errors/instrumentation.test.ts
+++ b/packages/instrumentation/src/errors/instrumentation.test.ts
@@ -19,7 +19,7 @@ import {
   vi,
 } from 'vitest';
 import { setupTestLogExporter } from '#utils/test';
-import { ExceptionInstrumentation } from './instrumentation.ts';
+import { ErrorsInstrumentation } from './instrumentation.ts';
 
 const EXCEPTION_EVENT_NAME = 'exception';
 const STRING_ERROR = 'Some error string.';
@@ -58,9 +58,9 @@ const dispatchUnhandledRejection = (reason: Error | string) => {
   window.dispatchEvent(event);
 };
 
-describe('ExceptionInstrumentation', () => {
+describe('ErrorsInstrumentation', () => {
   let inMemoryExporter: InMemoryLogRecordExporter;
-  let instrumentation: ExceptionInstrumentation | undefined;
+  let instrumentation: ErrorsInstrumentation | undefined;
 
   beforeAll(() => {
     inMemoryExporter = setupTestLogExporter();
@@ -76,19 +76,19 @@ describe('ExceptionInstrumentation', () => {
     inMemoryExporter.reset();
   });
 
-  const getExceptionLogs = () =>
+  const getErrorLogs = () =>
     inMemoryExporter
       .getFinishedLogRecords()
       .filter((log) => log.eventName === EXCEPTION_EVENT_NAME);
 
   describe('lifecycle', () => {
     it('should create an instance', () => {
-      instrumentation = new ExceptionInstrumentation({ enabled: false });
-      expect(instrumentation).toBeInstanceOf(ExceptionInstrumentation);
+      instrumentation = new ErrorsInstrumentation({ enabled: false });
+      expect(instrumentation).toBeInstanceOf(ErrorsInstrumentation);
     });
 
     it('should enable and disable without errors', () => {
-      instrumentation = new ExceptionInstrumentation({ enabled: false });
+      instrumentation = new ErrorsInstrumentation({ enabled: false });
       expect(() => {
         instrumentation?.enable();
         instrumentation?.disable();
@@ -96,17 +96,17 @@ describe('ExceptionInstrumentation', () => {
     });
 
     it('should not emit after disable', () => {
-      instrumentation = new ExceptionInstrumentation({ enabled: false });
+      instrumentation = new ErrorsInstrumentation({ enabled: false });
       instrumentation.enable();
       instrumentation.disable();
 
       dispatchErrorEvent(new Error('after disable'));
 
-      expect(getExceptionLogs()).toHaveLength(0);
+      expect(getErrorLogs()).toHaveLength(0);
     });
 
     it('should not double-subscribe when enabling twice', () => {
-      instrumentation = new ExceptionInstrumentation({ enabled: false });
+      instrumentation = new ErrorsInstrumentation({ enabled: false });
       const addSpy = vi.spyOn(window, 'addEventListener');
 
       instrumentation.enable();
@@ -125,14 +125,14 @@ describe('ExceptionInstrumentation', () => {
 
   describe('error events', () => {
     beforeEach(() => {
-      instrumentation = new ExceptionInstrumentation({ enabled: false });
+      instrumentation = new ErrorsInstrumentation({ enabled: false });
       instrumentation.enable();
     });
 
     it('should emit an exception event when an Error is thrown', () => {
       dispatchErrorEvent(new ValidationError('Something happened!'));
 
-      const logs = getExceptionLogs();
+      const logs = getErrorLogs();
       expect(logs).toHaveLength(1);
       expect(logs[0]?.eventName).toBe(EXCEPTION_EVENT_NAME);
     });
@@ -148,7 +148,7 @@ describe('ExceptionInstrumentation', () => {
 
       dispatchErrorEvent(error);
 
-      const logs = getExceptionLogs();
+      const logs = getErrorLogs();
       expect(logs).toHaveLength(1);
       expect(logs[0]?.attributes[ATTR_EXCEPTION_TYPE]).toBe('ValidationError');
       expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe(
@@ -160,7 +160,7 @@ describe('ExceptionInstrumentation', () => {
     it('should handle a string error', () => {
       dispatchErrorEvent(STRING_ERROR);
 
-      const logs = getExceptionLogs();
+      const logs = getErrorLogs();
       expect(logs).toHaveLength(1);
       expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe(STRING_ERROR);
       expect(logs[0]?.attributes[ATTR_EXCEPTION_TYPE]).toBeUndefined();
@@ -170,13 +170,13 @@ describe('ExceptionInstrumentation', () => {
     it('should not emit when the error is missing', () => {
       dispatchErrorEvent();
 
-      expect(getExceptionLogs()).toHaveLength(0);
+      expect(getErrorLogs()).toHaveLength(0);
     });
   });
 
   describe('unhandled rejection events', () => {
     beforeEach(() => {
-      instrumentation = new ExceptionInstrumentation({ enabled: false });
+      instrumentation = new ErrorsInstrumentation({ enabled: false });
       instrumentation.enable();
     });
 
@@ -184,7 +184,7 @@ describe('ExceptionInstrumentation', () => {
       const error = new ValidationError('Rejected!');
       dispatchUnhandledRejection(error);
 
-      const logs = getExceptionLogs();
+      const logs = getErrorLogs();
       expect(logs).toHaveLength(1);
       expect(logs[0]?.attributes[ATTR_EXCEPTION_TYPE]).toBe('ValidationError');
       expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe('Rejected!');
@@ -193,7 +193,7 @@ describe('ExceptionInstrumentation', () => {
     it('should emit an exception event when a promise is rejected with a string', () => {
       dispatchUnhandledRejection(STRING_ERROR);
 
-      const logs = getExceptionLogs();
+      const logs = getErrorLogs();
       expect(logs).toHaveLength(1);
       expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe(STRING_ERROR);
       expect(logs[0]?.attributes[ATTR_EXCEPTION_TYPE]).toBeUndefined();
@@ -202,7 +202,7 @@ describe('ExceptionInstrumentation', () => {
 
   describe('applyCustomAttributes', () => {
     it('should merge custom attributes for Error objects', () => {
-      instrumentation = new ExceptionInstrumentation({
+      instrumentation = new ErrorsInstrumentation({
         enabled: false,
         applyCustomAttributes: (error) => ({
           'app.custom.exception':
@@ -215,7 +215,7 @@ describe('ExceptionInstrumentation', () => {
 
       dispatchErrorEvent(new ValidationError('Something happened!'));
 
-      const logs = getExceptionLogs();
+      const logs = getErrorLogs();
       expect(logs).toHaveLength(1);
       expect(logs[0]?.attributes['app.custom.exception']).toBe(
         'SOMETHING HAPPENED!',
@@ -224,7 +224,7 @@ describe('ExceptionInstrumentation', () => {
     });
 
     it('should merge custom attributes for string errors', () => {
-      instrumentation = new ExceptionInstrumentation({
+      instrumentation = new ErrorsInstrumentation({
         enabled: false,
         applyCustomAttributes: (error) => ({
           'app.custom.exception':
@@ -237,7 +237,7 @@ describe('ExceptionInstrumentation', () => {
 
       dispatchErrorEvent(STRING_ERROR);
 
-      const logs = getExceptionLogs();
+      const logs = getErrorLogs();
       expect(logs).toHaveLength(1);
       expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe(STRING_ERROR);
       expect(logs[0]?.attributes['app.custom.exception']).toBe(
@@ -246,7 +246,7 @@ describe('ExceptionInstrumentation', () => {
     });
 
     it('should still emit standard attributes when the hook throws', () => {
-      instrumentation = new ExceptionInstrumentation({
+      instrumentation = new ErrorsInstrumentation({
         enabled: false,
         applyCustomAttributes: () => {
           throw new Error('hook boom');
@@ -258,7 +258,7 @@ describe('ExceptionInstrumentation', () => {
         dispatchErrorEvent(new ValidationError('Something happened!')),
       ).not.toThrow();
 
-      const logs = getExceptionLogs();
+      const logs = getErrorLogs();
       expect(logs).toHaveLength(1);
       expect(logs[0]?.attributes[ATTR_EXCEPTION_TYPE]).toBe('ValidationError');
       expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe(

--- a/packages/instrumentation/src/errors/instrumentation.ts
+++ b/packages/instrumentation/src/errors/instrumentation.ts
@@ -16,11 +16,11 @@ import {
   ATTR_EXCEPTION_TYPE,
 } from '@opentelemetry/semantic-conventions';
 import { version } from '../../package.json' with { type: 'json' };
-import type { ExceptionInstrumentationConfig } from './types.ts';
+import type { ErrorsInstrumentationConfig } from './types.ts';
 
 const EXCEPTION_EVENT_NAME = 'exception';
 
-export class ExceptionInstrumentation extends InstrumentationBase<ExceptionInstrumentationConfig> {
+export class ErrorsInstrumentation extends InstrumentationBase<ErrorsInstrumentationConfig> {
   // Use `declare` to prevent JS class field initializers from running after
   // super(), which would reset values set by the enable() call that
   // InstrumentationBase makes during its constructor.
@@ -29,7 +29,7 @@ export class ExceptionInstrumentation extends InstrumentationBase<ExceptionInstr
     event: ErrorEvent | PromiseRejectionEvent,
   ) => void;
 
-  constructor(config: ExceptionInstrumentationConfig = {}) {
+  constructor(config: ErrorsInstrumentationConfig = {}) {
     super('@opentelemetry/browser-instrumentation/errors', version, config);
   }
 

--- a/packages/instrumentation/src/errors/types.ts
+++ b/packages/instrumentation/src/errors/types.ts
@@ -11,9 +11,9 @@ export type ApplyCustomAttributesFunction = (
 ) => Attributes;
 
 /**
- * ExceptionInstrumentation Configuration
+ * ErrorsInstrumentation Configuration
  */
-export interface ExceptionInstrumentationConfig extends InstrumentationConfig {
+export interface ErrorsInstrumentationConfig extends InstrumentationConfig {
   /**
    * Optional callback invoked for each captured error or unhandled rejection.
    * Returned attributes are merged onto the emitted log record (after the


### PR DESCRIPTION
## Which problem is this PR solving?

Aligning the public class name with the subpath import (`@opentelemetry/browser-instrumentation/experimental/errors`) and the README section heading. The class is now `ErrorsInstrumentation` so the naming is consistent end-to-end.

## Short description of the changes

- Renames `ExceptionInstrumentation` to `ErrorsInstrumentation` and `ExceptionInstrumentationConfig` to `ErrorsInstrumentationConfig` across source, types, and tests.
- Updates the README import samples and the section heading/anchor from `Exception` to `Errors`.
- Clarifies the README description so it references `window.addEventListener('error', ...)` and `window.addEventListener('unhandledrejection', ...)`, matching the implementation.
- Sorts `keywords` and `exports` in `packages/instrumentation/package.json` alphabetically while reviewing the file.

The OpenTelemetry-spec `exception` event name and `exception.*` semantic-convention attribute keys are intentionally retained.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Existing unit tests in `packages/instrumentation/src/errors/instrumentation.test.ts` updated for the new class name and run via `npm run test`.
- [x] `npm run lint` and `npm run check` pass via the pre-commit hook.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated