### PR TITLE
(feat) Set context and body for log records emitted by instrumentation

### DIFF
--- a/packages/instrumentation/src/errors/instrumentation.test.ts
+++ b/packages/instrumentation/src/errors/instrumentation.test.ts
@@ -165,6 +165,7 @@ describe('ErrorsInstrumentation', () => {
       expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe(STRING_ERROR);
       expect(logs[0]?.attributes[ATTR_EXCEPTION_TYPE]).toBeUndefined();
       expect(logs[0]?.attributes[ATTR_EXCEPTION_STACKTRACE]).toBeUndefined();
+      expect(logs[0]?.body).toBe(`unhandled: ${STRING_ERROR}`);
     });
 
     it('should not emit when the error is missing', () => {
@@ -188,6 +189,7 @@ describe('ErrorsInstrumentation', () => {
       expect(logs).toHaveLength(1);
       expect(logs[0]?.attributes[ATTR_EXCEPTION_TYPE]).toBe('ValidationError');
       expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe('Rejected!');
+      expect(logs[0]?.body).toBe('unhandled: ValidationError');
     });
 
     it('should emit an exception event when a promise is rejected with a string', () => {
@@ -197,6 +199,7 @@ describe('ErrorsInstrumentation', () => {
       expect(logs).toHaveLength(1);
       expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe(STRING_ERROR);
       expect(logs[0]?.attributes[ATTR_EXCEPTION_TYPE]).toBeUndefined();
+      expect(logs[0]?.body).toBe(`unhandled: ${STRING_ERROR}`);
     });
   });
 

--- a/packages/instrumentation/src/errors/instrumentation.ts
+++ b/packages/instrumentation/src/errors/instrumentation.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Attributes } from '@opentelemetry/api';
+import { context } from '@opentelemetry/api';
 import type { AnyValueMap, LogRecord } from '@opentelemetry/api-logs';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import {
@@ -81,11 +82,14 @@ export class ErrorsInstrumentation extends InstrumentationBase<ErrorsInstrumenta
     }
 
     const customAttributes = this._applyCustomAttributes(error);
+    const errorContext = context.active();
 
     const logRecord: LogRecord = {
       eventName: EXCEPTION_EVENT_NAME,
       severityNumber: SeverityNumber.ERROR,
       attributes: { ...errorAttributes, ...customAttributes },
+      context: errorContext,
+      body: `unhandled: ${typeof error === 'string' ? error : errorAttributes[ATTR_EXCEPTION_TYPE]}`,
     };
 
     this.logger.emit(logRecord);

--- a/packages/instrumentation/src/navigation-timing/instrumentation.test.ts
+++ b/packages/instrumentation/src/navigation-timing/instrumentation.test.ts
@@ -123,6 +123,7 @@ describe('NavigationTimingInstrumentation', () => {
     expect(logs.length).toBe(1);
     expect(logs[0]?.eventName).toBe(NAVIGATION_TIMING_EVENT_NAME);
     expect(logs[0]?.attributes[ATTR_NAVIGATION_LOAD_EVENT_END]).toBe(456);
+    expect(logs[0]?.body).toBe('navigation timing for navigate');
   });
 
   it('should emit on construction when enabled by default and page is still loading', () => {
@@ -150,6 +151,7 @@ describe('NavigationTimingInstrumentation', () => {
     const logs = getNavigationTimingLogs();
     expect(logs.length).toBe(1);
     expect(logs[0]?.attributes[ATTR_NAVIGATION_LOAD_EVENT_END]).toBe(456);
+    expect(logs[0]?.body).toBe('navigation timing for navigate');
 
     inst.disable();
   });
@@ -450,6 +452,7 @@ describe('NavigationTimingInstrumentation', () => {
     expect(logs[0]?.attributes[ATTR_NAVIGATION_TRANSFER_SIZE]).toBe(1024);
     expect(logs[0]?.attributes[ATTR_NAVIGATION_ENCODED_BODY_SIZE]).toBe(800);
     expect(logs[0]?.attributes[ATTR_NAVIGATION_DECODED_BODY_SIZE]).toBe(2000);
+    expect(logs[0]?.body).toBe('navigation timing for navigate');
   });
 
   it('should work correctly when disable() is called then immediately enable() again', () => {

--- a/packages/instrumentation/src/navigation-timing/instrumentation.ts
+++ b/packages/instrumentation/src/navigation-timing/instrumentation.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { context } from '@opentelemetry/api';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { InstrumentationBase } from '@opentelemetry/instrumentation';
 import { version } from '../../package.json' with { type: 'json' };
@@ -201,6 +202,7 @@ export class NavigationTimingInstrumentation extends InstrumentationBase<Navigat
       return;
     }
 
+    const navigationContext = context.active();
     this.logger.emit({
       eventName: NAVIGATION_TIMING_EVENT_NAME,
       severityNumber: SeverityNumber.INFO,
@@ -232,6 +234,8 @@ export class NavigationTimingInstrumentation extends InstrumentationBase<Navigat
         [ATTR_NAVIGATION_ENCODED_BODY_SIZE]: entry.encodedBodySize,
         [ATTR_NAVIGATION_DECODED_BODY_SIZE]: entry.decodedBodySize,
       },
+      context: navigationContext,
+      body: `navigation timing for ${entry.type}`,
     });
   }
 

--- a/packages/instrumentation/src/navigation/instrumentation.test.ts
+++ b/packages/instrumentation/src/navigation/instrumentation.test.ts
@@ -114,6 +114,9 @@ describe('NavigationInstrumentation', () => {
       expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_HASH_CHANGE]).toBe(
         false,
       );
+      expect(logs[0]?.body).toBe(
+        'navigation: hard'
+      );
     });
 
     it('should emit on DOMContentLoaded when readyState is loading', () => {
@@ -129,6 +132,9 @@ describe('NavigationInstrumentation', () => {
       expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_SAME_DOCUMENT]).toBe(
         false,
       );
+      expect(logs[0]?.body).toBe(
+        'navigation: hard'
+      )
     });
 
     it('should not emit a duplicate initial event if DOMContentLoaded fires twice', () => {
@@ -161,6 +167,9 @@ describe('NavigationInstrumentation', () => {
       expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_HASH_CHANGE]).toBe(
         false,
       );
+      expect(logs[0]?.body).toBe(
+        'navigation: push'
+      );
     });
 
     it('should emit a replace event when history.replaceState is called', () => {
@@ -174,6 +183,7 @@ describe('NavigationInstrumentation', () => {
       const logs = getNavigationLogs();
       expect(logs).toHaveLength(1);
       expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_TYPE]).toBe('replace');
+      expect(logs[0]?.body).toBe('navigation: replace');
     });
 
     it('should not emit when pushState is called twice with the same URL', () => {
@@ -224,6 +234,9 @@ describe('NavigationInstrumentation', () => {
       expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_TYPE]).toBe(
         'traverse',
       );
+      expect(logs[0]?.body).toBe(
+        'navigation: traverse'
+      );
     });
   });
 
@@ -240,6 +253,9 @@ describe('NavigationInstrumentation', () => {
       expect(logs).toHaveLength(1);
       expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_HASH_CHANGE]).toBe(
         true,
+      );
+      expect(logs[0]?.body).toBe(
+        'navigation: push'
       );
     });
 
@@ -432,6 +448,7 @@ describe('NavigationInstrumentation', () => {
         'http://localhost/nav-api-path',
       );
       expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_TYPE]).toBe('push');
+      expect(logs[0]?.body).toBe('navigation: push');
 
       restore();
     });
@@ -455,6 +472,7 @@ describe('NavigationInstrumentation', () => {
       const logs = getNavigationLogs();
       expect(logs).toHaveLength(1);
       expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_TYPE]).toBe('push');
+      expect(logs[0]?.body).toBe('navigation: push');
     });
 
     it('should map currententrychange navigationType values correctly', () => {
@@ -481,6 +499,9 @@ describe('NavigationInstrumentation', () => {
       const logs = getNavigationLogs();
       expect(logs[0]?.attributes[ATTR_BROWSER_NAVIGATION_TYPE]).toBe(
         'traverse',
+      );
+      expect(logs[0]?.body).toBe(
+        'navigation: traverse'
       );
 
       restore();

--- a/packages/instrumentation/src/navigation/instrumentation.ts
+++ b/packages/instrumentation/src/navigation/instrumentation.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { context } from '@opentelemetry/api';
 import type { LogRecord } from '@opentelemetry/api-logs';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import {
@@ -145,6 +146,7 @@ export class NavigationInstrumentation extends InstrumentationBase<NavigationIns
 
   private _onHardNavigation(): void {
     const cfg = this.getConfig();
+    const navigationContext = context.active();
     const logRecord: LogRecord = {
       eventName: BROWSER_NAVIGATION_EVENT_NAME,
       severityNumber: SeverityNumber.INFO,
@@ -155,6 +157,8 @@ export class NavigationInstrumentation extends InstrumentationBase<NavigationIns
         [ATTR_BROWSER_NAVIGATION_SAME_DOCUMENT]: false,
         [ATTR_BROWSER_NAVIGATION_HASH_CHANGE]: false,
       },
+      context: navigationContext,
+      body: 'navigation: hard',
     };
     this._applyCustomLogRecordData(logRecord);
     this.logger.emit(logRecord);
@@ -179,6 +183,7 @@ export class NavigationInstrumentation extends InstrumentationBase<NavigationIns
     const sameDocument = this._determineSameDocument(referrerUrl, currentUrl);
     const hashChange = isHashChange(referrerUrl, currentUrl);
     const cfg = this.getConfig();
+    const navigationContext = context.active();
 
     const logRecord: LogRecord = {
       eventName: BROWSER_NAVIGATION_EVENT_NAME,
@@ -191,6 +196,8 @@ export class NavigationInstrumentation extends InstrumentationBase<NavigationIns
         [ATTR_BROWSER_NAVIGATION_HASH_CHANGE]: hashChange,
         ...(navType ? { [ATTR_BROWSER_NAVIGATION_TYPE]: navType } : {}),
       },
+      context: navigationContext,
+      body: `navigation: ${navType}`,
     };
     this._applyCustomLogRecordData(logRecord);
     this.logger.emit(logRecord);

--- a/packages/instrumentation/src/resource-timing/instrumentation.test.ts
+++ b/packages/instrumentation/src/resource-timing/instrumentation.test.ts
@@ -581,6 +581,7 @@ describe('ResourceTimingInstrumentation', () => {
       expect(
         (records[0] as unknown as { eventName: string } | undefined)?.eventName,
       ).toBe(RESOURCE_TIMING_EVENT_NAME);
+      expect(records[0]?.body).toBe('resource timing for https://example.com/script.js');
     });
 
     it('should flush on visibility change', () => {

--- a/packages/instrumentation/src/resource-timing/instrumentation.ts
+++ b/packages/instrumentation/src/resource-timing/instrumentation.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { context } from '@opentelemetry/api';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { isUrlIgnored } from '@opentelemetry/core';
 import { InstrumentationBase } from '@opentelemetry/instrumentation';
@@ -246,6 +247,7 @@ export class ResourceTimingInstrumentation extends InstrumentationBase<ResourceT
 
   private _emitResource(entry: PerformanceResourceTiming): void {
     try {
+      const resourceContext = context.active();
       this.logger.emit({
         eventName: RESOURCE_TIMING_EVENT_NAME,
         severityNumber: SeverityNumber.INFO,
@@ -272,6 +274,8 @@ export class ResourceTimingInstrumentation extends InstrumentationBase<ResourceT
           // @ts-expect-error renderBlockingStatus is only available in Chromium as of March 2026
           [ATTR_RESOURCE_RENDER_BLOCKING_STATUS]: entry.renderBlockingStatus,
         },
+        context: resourceContext,
+        body: `resource timing for ${entry.name}`,
       });
     } catch (error) {
       this._diag.error(

--- a/packages/instrumentation/src/user-action/instrumentation.test.ts
+++ b/packages/instrumentation/src/user-action/instrumentation.test.ts
@@ -63,6 +63,7 @@ describe('UserActionInstrumentation', () => {
     expect(log?.attributes['browser.page.y']).toBe(150);
     expect(log?.attributes['browser.tag_name']).toBe('DIV');
     expect(log?.attributes['browser.css_selector']).toBe('html > body > div');
+    expect(log?.body).toBe('click (left) on html > body > div');
   });
 
   it('should emit a log when the element triggers a mousedown event with the right and middle click', () => {
@@ -78,10 +79,16 @@ describe('UserActionInstrumentation', () => {
     expect(middleClickLog?.attributes['browser.mouse_event.button']).toBe(
       'middle',
     );
+    expect(middleClickLog?.body).toMatch(
+      'click (middle)'
+    );
 
     const rightClickLog = logs[1];
     expect(rightClickLog?.attributes['browser.mouse_event.button']).toBe(
       'right',
+    );
+    expect(rightClickLog?.body).toMatch(
+      'click (right)'
     );
   });
 

--- a/packages/instrumentation/src/user-action/instrumentation.ts
+++ b/packages/instrumentation/src/user-action/instrumentation.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { context } from '@opentelemetry/api';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { InstrumentationBase } from '@opentelemetry/instrumentation';
 import { getElementCSSSelector } from '#utils';
@@ -82,6 +83,9 @@ export class UserActionInstrumentation extends InstrumentationBase<UserActionIns
       }
     }
 
+    const userActionContext = context.active();
+    const mouseButton = this._getMouseButtonFromMouseEvent(event);
+
     this.logger.emit({
       severityNumber: SeverityNumber.INFO,
       eventName: CLICK_EVENT_NAME,
@@ -90,9 +94,11 @@ export class UserActionInstrumentation extends InstrumentationBase<UserActionIns
         [ATTR_PAGE_Y]: event.pageY,
         [ATTR_TAG_NAME]: element.tagName,
         [ATTR_TAGS]: otelPrefixedAttributes,
-        [ATTR_MOUSE_EVENT_BUTTON]: this._getMouseButtonFromMouseEvent(event),
-        [ATTR_CSS_SELECTOR]: cssSelector,
+        [ATTR_MOUSE_EVENT_BUTTON]: mouseButton,
+        [ATTR_CSS_SELECTOR]: cssSelector,  
       },
+      context: userActionContext,
+      body: `click (${mouseButton}) on ${cssSelector}`,
     });
   }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

From Grafana: 
<img width="575" height="200" alt="grafik" src="https://github.com/user-attachments/assets/2cfe51a5-ed72-4cf2-8e47-28500d00d411" />

There's no body in the log records, so it's hard to spot which instrumenation emitted the log. This is only seeable in the details.

## Short description of the changes

## Type of change

The `body` is set on the emitted log records, as well the `context.active()` set, so that there's a potential link to traces in order to make observability more seamless.

With this change it looks in Grafana like 
<img width="553" height="136" alt="grafik" src="https://github.com/user-attachments/assets/0d4137a8-afa0-4ab5-bd57-f3741c0ed042" />

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

An alternative to this PR could be using a transformer in the OTel-collector, but this is not very user-friendly.
Also when the setup doesn't use OTel-collector the logs will look empty again.

## How Has This Been Tested?

Added assertions to the unit tests, and manual verification.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
