### PR TITLE
feat: migrate fetch instrumentation from opentelemetry-js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ dist
 
 # AI agent rules
 AGENTS.md
+.claude
+
+# Test output
+.vitest-attachments
+**/*/coverage

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "e2e-tests",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/api-logs": "^0.217.0",
+    "@opentelemetry/browser-instrumentation": "file:../packages/instrumentation",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.217.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.217.0",
+    "@opentelemetry/instrumentation": "^0.217.0",
+    "@opentelemetry/sdk-logs": "^0.217.0",
+    "@opentelemetry/sdk-trace-web": "^2.7.1",
+    "msw": "^2.14.6"
+  }
+}

--- a/e2e-tests/packages/instrumentation/fetch/instrumentation.test.ts
+++ b/e2e-tests/packages/instrumentation/fetch/instrumentation.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FetchInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/fetch';
+import { HttpResponse, http } from 'msw';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import {
+  COLLECTOR_URL,
+  LOGS_COLLECTOR_URL,
+  startMsw,
+  stopMsw,
+} from '../../../utils/test-collector.ts';
+import type { TestOtelSetupResult } from '../../../utils/test-otel-setup.ts';
+import { testOtelSetup } from '../../../utils/test-otel-setup.ts';
+
+const TEST_URL = 'http://test.local/api';
+
+describe('FetchInstrumentation', () => {
+  let result: TestOtelSetupResult;
+
+  beforeAll(async () => {
+    await startMsw(
+      http.options(
+        TEST_URL,
+        () =>
+          new HttpResponse(null, {
+            status: 204,
+            headers: {
+              'Access-Control-Allow-Origin': '*',
+              'Access-Control-Allow-Methods': 'GET, OPTIONS',
+              'Access-Control-Allow-Headers':
+                'traceparent, tracestate, baggage',
+            },
+          }),
+      ),
+      http.get(TEST_URL, () =>
+        HttpResponse.json(
+          { ok: true },
+          {
+            headers: { 'Access-Control-Allow-Origin': '*' },
+          },
+        ),
+      ),
+    );
+  });
+
+  afterAll(() => {
+    stopMsw();
+  });
+
+  afterEach(async () => {
+    await result.cleanup();
+  });
+
+  it('creates a span for a fetch request and emits a network timing log', async () => {
+    result = testOtelSetup([
+      new FetchInstrumentation({
+        ignoreUrls: [COLLECTOR_URL, LOGS_COLLECTOR_URL],
+      }),
+    ]);
+
+    await fetch(TEST_URL);
+
+    await vi.waitFor(
+      () => {
+        const spans = result.getSpans();
+        expect(spans).toHaveLength(1);
+        const span = spans[0];
+        expect(span).toBeDefined();
+        if (!span) {
+          return;
+        }
+
+        expect(span.name).toBe('GET');
+        expect(span.kind).toBe(3); // SpanKind.CLIENT
+        expect(span.status.code).toBe(0); // SpanStatusCode.UNSET
+
+        const attr = (key: string) =>
+          span.attributes.find((a) => a.key === key)?.value;
+
+        expect(attr('http.request.method')).toEqual({ stringValue: 'GET' });
+        expect(attr('url.full')).toEqual({ stringValue: TEST_URL });
+        expect(attr('http.response.status_code')).toEqual({ intValue: 200 });
+        expect(attr('server.address')).toEqual({ stringValue: 'test.local' });
+        expect(attr('server.port')).toEqual({ intValue: 80 });
+        expect(attr('error.type')).toBeUndefined();
+
+        const logRecords = result.getLogs();
+        expect(logRecords).toHaveLength(1);
+        const logRecord = logRecords[0];
+        expect(logRecord).toBeDefined();
+        if (!logRecord) {
+          return;
+        }
+
+        const logAttr = (key: string) =>
+          logRecord.attributes.find((a) => a.key === key)?.value;
+
+        expect(logAttr('fetchStart')).toBeDefined();
+        expect(logAttr('domainLookupStart')).toBeDefined();
+        expect(logAttr('domainLookupEnd')).toBeDefined();
+        expect(logAttr('connectStart')).toBeDefined();
+        expect(logAttr('connectEnd')).toBeDefined();
+        expect(logAttr('requestStart')).toBeDefined();
+        expect(logAttr('responseStart')).toBeDefined();
+        expect(logAttr('responseEnd')).toBeDefined();
+
+        expect(logRecord.traceId).toBe(span.traceId);
+        expect(logRecord.spanId).toBe(span.spanId);
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('does not emit a network timing log when ignoreNetworkEvents is true', async () => {
+    result = testOtelSetup([
+      new FetchInstrumentation({
+        ignoreUrls: [COLLECTOR_URL, LOGS_COLLECTOR_URL],
+        ignoreNetworkEvents: true,
+      }),
+    ]);
+
+    await fetch(TEST_URL);
+
+    await vi.waitFor(
+      () => {
+        const spans = result.getSpans();
+        expect(spans).toHaveLength(1);
+
+        const span = spans[0];
+        expect(span).toBeDefined();
+        if (!span) {
+          return;
+        }
+
+        expect(span.events).toHaveLength(0);
+        expect(result.getLogs()).toHaveLength(0);
+      },
+      { timeout: 2000 },
+    );
+  });
+});

--- a/e2e-tests/public/mockServiceWorker.js
+++ b/e2e-tests/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.14.6'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/e2e-tests/utils/test-collector.ts
+++ b/e2e-tests/utils/test-collector.ts
@@ -1,0 +1,123 @@
+import type { HttpHandler } from 'msw';
+import { HttpResponse, http } from 'msw';
+import { setupWorker } from 'msw/browser';
+
+export const COLLECTOR_URL = 'http://localhost:4318/v1/traces';
+export const LOGS_COLLECTOR_URL = 'http://localhost:4318/v1/logs';
+
+// ── OTLP JSON types ────────────────────────────────────────────────────────────
+
+interface OtlpAnyValue {
+  stringValue?: string;
+  intValue?: number;
+  boolValue?: boolean;
+  doubleValue?: number;
+}
+
+export interface OtlpKeyValue {
+  key: string;
+  value: OtlpAnyValue;
+}
+
+export interface OtlpSpan {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  kind: number;
+  startTimeUnixNano: string;
+  endTimeUnixNano: string;
+  attributes: OtlpKeyValue[];
+  events: Array<{
+    name: string;
+    timeUnixNano: string;
+    attributes: OtlpKeyValue[];
+  }>;
+  status: { code: number; message?: string };
+}
+
+export interface OtlpLogRecord {
+  traceId?: string;
+  spanId?: string;
+  severityNumber?: number;
+  severityText?: string;
+  attributes: OtlpKeyValue[];
+}
+
+interface ExportTraceServiceRequest {
+  resourceSpans: Array<{
+    resource: { attributes: OtlpKeyValue[] };
+    scopeSpans: Array<{
+      scope: { name: string; version?: string };
+      spans: OtlpSpan[];
+    }>;
+  }>;
+}
+
+interface ExportLogsServiceRequest {
+  resourceLogs: Array<{
+    resource: { attributes: OtlpKeyValue[] };
+    scopeLogs: Array<{
+      scope: { name: string; version?: string };
+      logRecords: OtlpLogRecord[];
+    }>;
+  }>;
+}
+
+// ── MSW worker (singleton) ─────────────────────────────────────────────────────
+
+let worker: ReturnType<typeof setupWorker> | undefined;
+
+export async function startMsw(...handlers: HttpHandler[]): Promise<void> {
+  worker = setupWorker(...handlers);
+  await worker.start({ onUnhandledRequest: 'error', quiet: true });
+}
+
+export function stopMsw(): void {
+  worker?.stop();
+  worker = undefined;
+}
+
+// ── Test collector ─────────────────────────────────────────────────────────────
+
+export interface TestCollector {
+  getSpans: () => OtlpSpan[];
+  getLogs: () => OtlpLogRecord[];
+  cleanup: () => void;
+}
+
+export function setupCollector(): TestCollector {
+  const tracePayloads: ExportTraceServiceRequest[] = [];
+  const logPayloads: ExportLogsServiceRequest[] = [];
+
+  worker?.use(
+    http.post(COLLECTOR_URL, async ({ request }) => {
+      const payload = (await request.json()) as ExportTraceServiceRequest;
+      tracePayloads.push(payload);
+      return HttpResponse.json({});
+    }),
+    http.post(LOGS_COLLECTOR_URL, async ({ request }) => {
+      const payload = (await request.json()) as ExportLogsServiceRequest;
+      logPayloads.push(payload);
+      return HttpResponse.json({});
+    }),
+  );
+
+  return {
+    getSpans: () =>
+      tracePayloads.flatMap((p) =>
+        p.resourceSpans.flatMap((rs) =>
+          rs.scopeSpans.flatMap((ss) => ss.spans),
+        ),
+      ),
+    getLogs: () =>
+      logPayloads.flatMap((p) =>
+        p.resourceLogs.flatMap((rl) =>
+          rl.scopeLogs.flatMap((sl) => sl.logRecords),
+        ),
+      ),
+    cleanup: () => {
+      worker?.resetHandlers();
+    },
+  };
+}

--- a/e2e-tests/utils/test-otel-setup.ts
+++ b/e2e-tests/utils/test-otel-setup.ts
@@ -1,0 +1,65 @@
+import { trace } from '@opentelemetry/api';
+import { logs } from '@opentelemetry/api-logs';
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import type { Instrumentation } from '@opentelemetry/instrumentation';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import {
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+} from '@opentelemetry/sdk-logs';
+import {
+  SimpleSpanProcessor,
+  WebTracerProvider,
+} from '@opentelemetry/sdk-trace-web';
+import type { OtlpLogRecord, OtlpSpan } from './test-collector.ts';
+import {
+  COLLECTOR_URL,
+  LOGS_COLLECTOR_URL,
+  setupCollector,
+} from './test-collector.ts';
+
+export interface TestOtelSetupResult {
+  getSpans: () => OtlpSpan[];
+  getLogs: () => OtlpLogRecord[];
+  cleanup: () => Promise<void>;
+}
+
+export function testOtelSetup(
+  instrumentations: Instrumentation[],
+): TestOtelSetupResult {
+  const collector = setupCollector();
+
+  const traceExporter = new OTLPTraceExporter({
+    url: COLLECTOR_URL,
+    timeoutMillis: 1,
+  });
+  const provider = new WebTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(traceExporter)],
+  });
+  provider.register();
+
+  const logExporter = new OTLPLogExporter({
+    url: LOGS_COLLECTOR_URL,
+    timeoutMillis: 1,
+  });
+  const logProvider = new LoggerProvider({
+    processors: [new SimpleLogRecordProcessor(logExporter)],
+  });
+  logs.setGlobalLoggerProvider(logProvider);
+
+  const deregister = registerInstrumentations({ instrumentations });
+
+  return {
+    getSpans: collector.getSpans,
+    getLogs: collector.getLogs,
+    cleanup: async () => {
+      deregister();
+      await provider.shutdown();
+      await logProvider.shutdown();
+      trace.disable();
+      logs.disable();
+      collector.cleanup();
+    },
+  };
+}

--- a/e2e-tests/vitest.config.ts
+++ b/e2e-tests/vitest.config.ts
@@ -1,0 +1,28 @@
+import { fileURLToPath } from 'node:url';
+import { playwright } from '@vitest/browser-playwright';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  publicDir: 'e2e-tests/public',
+  resolve: {
+    alias: {
+      '@opentelemetry/browser-instrumentation/experimental/fetch':
+        fileURLToPath(
+          new URL(
+            '../packages/instrumentation/src/fetch/index.ts',
+            import.meta.url,
+          ),
+        ),
+    },
+  },
+  test: {
+    onConsoleLog: () => (process.env['VERBOSE'] ? undefined : false),
+    include: ['e2e-tests/**/*.test.ts'],
+    browser: {
+      provider: playwright(),
+      enabled: true,
+      headless: true,
+      instances: [{ browser: 'chromium' }],
+    },
+  },
+});

--- a/examples/with-tracing/src/main.ts
+++ b/examples/with-tracing/src/main.ts
@@ -60,11 +60,11 @@ registerInstrumentations({
 });
 
 // --- Button handlers ---
-document.getElementById('fetch-button')!.addEventListener('click', () => {
+document.getElementById('fetch-button')?.addEventListener('click', () => {
   fetch('https://httpbin.org/get');
 });
 
-document.getElementById('xhr-button')!.addEventListener('click', () => {
+document.getElementById('xhr-button')?.addEventListener('click', () => {
   const xhr = new XMLHttpRequest();
   xhr.open('GET', 'https://httpbin.org/get');
   xhr.send();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "workspaces": [
+        "e2e-tests",
         "examples/*",
         "packages/*",
         "sandbox"
@@ -36,6 +37,16 @@
       },
       "peerDependencies": {
         "typescript": "^6.0.3"
+      }
+    },
+    "e2e-tests": {
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/browser-instrumentation": "file:../packages/instrumentation",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.217.0",
+        "@opentelemetry/instrumentation": "^0.217.0",
+        "@opentelemetry/sdk-trace-web": "^2.7.1",
+        "msw": "^2.14.6"
       }
     },
     "examples/all-instrumentations": {
@@ -1482,6 +1493,29 @@
         "@braidai/lang": "^1.0.0"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -1500,6 +1534,28 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "license": "MIT"
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
@@ -2596,6 +2652,21 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "license": "MIT"
+    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -3076,7 +3147,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3086,7 +3156,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3303,7 +3372,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -3313,7 +3381,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -3328,7 +3395,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -3346,7 +3412,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3359,7 +3424,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/compare-func": {
@@ -3422,6 +3486,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
@@ -3579,11 +3656,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/e2e-tests": {
+      "resolved": "e2e-tests",
+      "link": true
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/empathic": {
@@ -3651,7 +3731,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3962,6 +4041,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -3978,6 +4072,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4075,7 +4178,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4127,6 +4229,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/graphql": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4135,6 +4246,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
       }
     },
     "node_modules/hookable": {
@@ -4304,7 +4425,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4322,6 +4442,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/is-obj": {
       "version": "2.0.0",
@@ -5152,6 +5278,141 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.6.tgz",
+      "integrity": "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.11",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/confirm": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.13.tgz",
+      "integrity": "sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/core": {
+      "version": "11.1.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.10.tgz",
+      "integrity": "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
@@ -5216,6 +5477,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -5321,6 +5588,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -5332,7 +5605,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -5529,7 +5801,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5577,6 +5848,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
+      "license": "MIT"
     },
     "node_modules/sade": {
       "version": "1.8.1",
@@ -5634,6 +5911,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5668,7 +5951,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -5709,6 +5991,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -5716,11 +6007,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "license": "MIT"
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5735,7 +6031,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5763,6 +6058,18 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -5812,7 +6119,6 @@
       "version": "7.0.29",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
       "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.29"
@@ -5825,7 +6131,6 @@
       "version": "7.0.29",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
       "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/totalist": {
@@ -5842,7 +6147,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -6474,6 +6778,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -6542,6 +6861,15 @@
       "integrity": "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -7227,7 +7555,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -7237,7 +7564,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -7256,7 +7582,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint:ci": "biome ci && npm run check",
     "validate": "node scripts/validate.js",
     "test": "turbo run test",
+    "test:e2e": "vitest run --config e2e-tests/vitest.config.ts",
     "test:watch": "turbo run test:watch",
     "test:coverage": "turbo run test:coverage"
   },
@@ -59,6 +60,7 @@
     "typescript": "^6.0.3"
   },
   "workspaces": [
+    "e2e-tests",
     "examples/*",
     "packages/*",
     "sandbox"

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -32,6 +32,7 @@
   "exports": {
     "./experimental/console": "./dist/console/index.js",
     "./experimental/errors": "./dist/errors/index.js",
+    "./experimental/fetch": "./dist/fetch/index.js",
     "./experimental/navigation": "./dist/navigation/index.js",
     "./experimental/navigation-timing": "./dist/navigation-timing/index.js",
     "./experimental/resource-timing": "./dist/resource-timing/index.js",
@@ -59,7 +60,8 @@
     "@opentelemetry/api": "^1.9.1"
   },
   "devDependencies": {
-    "@opentelemetry/sdk-logs": "0.217.0"
+    "@opentelemetry/sdk-logs": "0.217.0",
+    "@opentelemetry/sdk-trace-base": "^2.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/instrumentation/src/fetch/index.ts
+++ b/packages/instrumentation/src/fetch/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { FetchInstrumentation } from './instrumentation.ts';
+export type {
+  FetchCustomAttributeFunction,
+  FetchInstrumentationConfig,
+  FetchRequestHookFunction,
+  PropagateTraceHeaderCorsUrls,
+} from './types.ts';

--- a/packages/instrumentation/src/fetch/instrumentation.test.ts
+++ b/packages/instrumentation/src/fetch/instrumentation.test.ts
@@ -1,0 +1,844 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  propagation,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+} from '@opentelemetry/api';
+import { logs } from '@opentelemetry/api-logs';
+import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
+import type {
+  InMemorySpanExporter,
+  ReadableSpan,
+} from '@opentelemetry/sdk-trace-base';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestLogExporter, setupTestSpanExporter } from '#utils/test';
+import { FetchInstrumentation } from './instrumentation.ts';
+import {
+  ATTR_HTTP_REQUEST_BODY_SIZE,
+  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_HTTP_REQUEST_METHOD_ORIGINAL,
+  ATTR_HTTP_RESPONSE_STATUS_CODE,
+  ATTR_SERVER_ADDRESS,
+  ATTR_SERVER_PORT,
+  ATTR_URL_FULL,
+} from './semconv.ts';
+import type { FetchInstrumentationConfig } from './types.ts';
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+function makeResponse(status = 200, body = 'ok'): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': 'text/plain' },
+  });
+}
+
+async function flushSpanEnd(): Promise<void> {
+  await vi.runAllTimersAsync();
+}
+
+// ─── Test setup ───────────────────────────────────────────────────────────────
+
+describe('FetchInstrumentation', () => {
+  let exporter: InMemorySpanExporter;
+  let logExporter: InMemoryLogRecordExporter;
+  let instrumentation: FetchInstrumentation;
+  let mockFetch: ReturnType<typeof vi.fn>;
+  const originalFetch = globalThis.fetch;
+
+  /**
+   * Creates a mock fetch, registers a new TracerProvider, and enables the
+   * instrumentation so that `globalThis.fetch` is patched around mockFetch.
+   * Must be called before any test that exercises the instrumentation.
+   */
+  function setupInstrumentation(config: FetchInstrumentationConfig = {}): void {
+    instrumentation?.disable();
+    trace.disable();
+    logs.disable();
+
+    mockFetch = vi.fn().mockResolvedValue(makeResponse());
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    exporter = setupTestSpanExporter();
+    logExporter = setupTestLogExporter();
+
+    instrumentation = new FetchInstrumentation({ enabled: false, ...config });
+    instrumentation.enable();
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setupInstrumentation();
+  });
+
+  afterEach(async () => {
+    await vi.runAllTimersAsync();
+    instrumentation?.disable();
+    globalThis.fetch = originalFetch;
+    trace.disable();
+    logs.disable();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  const getSpans = () => exporter.getFinishedSpans();
+  const getMainSpan = () =>
+    getSpans().find((s) => s.name !== 'CORS Preflight') as
+      | ReadableSpan
+      | undefined;
+  const getLogs = () => logExporter.getFinishedLogRecords();
+
+  // ─── Lifecycle ──────────────────────────────────────────────────────────────
+
+  describe('lifecycle', () => {
+    it('creates an instance', () => {
+      expect(instrumentation).toBeInstanceOf(FetchInstrumentation);
+    });
+
+    it('patches globalThis.fetch on enable', () => {
+      expect(globalThis.fetch).not.toBe(mockFetch);
+    });
+
+    it('passes through when disabled', async () => {
+      instrumentation.disable();
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+      expect(getSpans()).toHaveLength(0);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-enables without double-patching', () => {
+      instrumentation.disable();
+      instrumentation.enable();
+      expect(getSpans()).toHaveLength(0);
+    });
+
+    it('is a no-op when enable() is called while already enabled', () => {
+      instrumentation.enable(); // already enabled — hits the early-return on line 405
+      expect(globalThis.fetch).not.toBe(mockFetch); // still patched, not double-wrapped
+    });
+
+    it('handles globalThis.fetch being non-writable without throwing', () => {
+      const inst = new FetchInstrumentation({ enabled: false });
+      // biome-ignore lint/suspicious/noExplicitAny: accessing private method for testing
+      vi.spyOn(inst as any, '_wrap').mockImplementation(() => {
+        throw new Error('_wrap failed');
+      });
+      expect(() => inst.enable()).not.toThrow();
+    });
+  });
+
+  // ─── Span creation and attributes ───────────────────────────────────────────
+
+  describe('span attributes', () => {
+    it('creates a CLIENT span for a successful fetch', async () => {
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      const span = getMainSpan();
+      expect(span).toBeDefined();
+
+      if (!span) {
+        return;
+      }
+
+      expect(span.kind).toBe(SpanKind.CLIENT);
+    });
+
+    it('sets http.request.method to the normalized method', async () => {
+      fetch('http://localhost/api', { method: 'POST' });
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.attributes[ATTR_HTTP_REQUEST_METHOD]).toBe('POST');
+    });
+
+    it('defaults to GET when no method is specified', async () => {
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.attributes[ATTR_HTTP_REQUEST_METHOD]).toBe('GET');
+    });
+
+    it('normalizes unknown methods to _OTHER', async () => {
+      fetch('http://localhost/api', { method: 'BREW' });
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.attributes[ATTR_HTTP_REQUEST_METHOD]).toBe(
+        '_OTHER',
+      );
+    });
+
+    it('sets http.request.method.original when method is normalized to _OTHER', async () => {
+      fetch('http://localhost/api', { method: 'BREW' });
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.attributes[ATTR_HTTP_REQUEST_METHOD_ORIGINAL]).toBe(
+        'BREW',
+      );
+    });
+
+    it('span name equals the normalized HTTP method', async () => {
+      fetch('http://localhost/api', { method: 'POST' });
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.name).toBe('POST');
+    });
+
+    it('sets url.full', async () => {
+      fetch('http://localhost/api?q=1');
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.attributes[ATTR_URL_FULL]).toBe(
+        'http://localhost/api?q=1',
+      );
+    });
+
+    it('sets http.response.status_code on success', async () => {
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE]).toBe(
+        200,
+      );
+    });
+
+    it('sets server.address', async () => {
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.attributes[ATTR_SERVER_ADDRESS]).toBe('localhost');
+    });
+
+    it('sets server.port for non-default ports', async () => {
+      // Response.url is set by the browser on real fetches; override it here
+      // so _addFinalSpanAttributes sees the correct host+port.
+      const response = makeResponse();
+      Object.defineProperty(response, 'url', {
+        value: 'http://localhost:8080/api',
+      });
+      mockFetch.mockResolvedValue(response);
+
+      fetch('http://localhost:8080/api');
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.attributes[ATTR_SERVER_PORT]).toBe(8080);
+    });
+
+    it('ends the span when the response has no body', async () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 204 }));
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      const span = getMainSpan();
+      expect(span?.ended).toBe(true);
+      expect(span?.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE]).toBe(204);
+    });
+
+    it('sets error status and error.type for 4xx responses', async () => {
+      mockFetch.mockResolvedValue(makeResponse(404, 'not found'));
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      const span = getMainSpan();
+      expect(span?.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE]).toBe(404);
+      expect(span?.status.code).toBe(SpanStatusCode.ERROR);
+      expect(span?.attributes['error.type']).toBe('404');
+    });
+
+    it('sets error status and error.type for 5xx responses', async () => {
+      mockFetch.mockResolvedValue(makeResponse(500, 'internal server error'));
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      const span = getMainSpan();
+      expect(span?.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE]).toBe(500);
+      expect(span?.status.code).toBe(SpanStatusCode.ERROR);
+      expect(span?.attributes['error.type']).toBe('500');
+    });
+
+    it('ends the span on a network-level fetch error', async () => {
+      mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+      await expect(fetch('http://localhost/api')).rejects.toThrow();
+      await flushSpanEnd();
+
+      const span = getMainSpan();
+      expect(span).toBeDefined();
+      expect(span?.ended).toBe(true);
+    });
+  });
+
+  // ─── ignoreUrls ──────────────────────────────────────────────────────────────
+
+  describe('ignoreUrls', () => {
+    it('does not create a span for a URL matching a string pattern', async () => {
+      setupInstrumentation({ ignoreUrls: ['http://localhost/ignored'] });
+
+      fetch('http://localhost/ignored');
+      await flushSpanEnd();
+
+      expect(getSpans()).toHaveLength(0);
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it('does not create a span for a URL matching a regexp', async () => {
+      setupInstrumentation({ ignoreUrls: [/\/health/] });
+
+      fetch('http://localhost/health');
+      await flushSpanEnd();
+
+      expect(getSpans()).toHaveLength(0);
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it('still creates a span for non-matching URLs', async () => {
+      setupInstrumentation({ ignoreUrls: [/\/health/] });
+
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      expect(getSpans()).toHaveLength(1);
+    });
+  });
+
+  // ─── Header injection ─────────────────────────────────────────────────────
+
+  describe('trace header injection', () => {
+    const TEST_HEADER = 'x-test-trace';
+    const TEST_VALUE = 'test-value-123';
+
+    // Simulates a real propagator injecting a known header so we can assert
+    // it reaches the underlying fetch call.
+    function mockPropagation(): void {
+      vi.spyOn(propagation, 'inject').mockImplementation(
+        (_ctx, carrier, setter) => {
+          setter?.set(carrier as Headers, TEST_HEADER, TEST_VALUE);
+        },
+      );
+    }
+
+    it('injects trace headers into the request for same-origin requests', async () => {
+      mockPropagation();
+
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(new Headers(init?.headers).get(TEST_HEADER)).toBe(TEST_VALUE);
+    });
+
+    it('does not inject trace headers for cross-origin requests not in the allowlist', async () => {
+      mockPropagation();
+
+      fetch('https://other.example.com/api');
+      await flushSpanEnd();
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(new Headers(init?.headers).get(TEST_HEADER)).toBeNull();
+    });
+
+    it('logs a debug message when propagation has headers to inject but CORS blocks them', async () => {
+      vi.spyOn(propagation, 'inject').mockImplementation((_ctx, carrier) => {
+        (carrier as Record<string, string>)['traceparent'] = '00-abc-def-01';
+      });
+
+      fetch('https://other.example.com/api');
+      await flushSpanEnd();
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(new Headers(init?.headers).get('traceparent')).toBeNull();
+    });
+
+    it('injects headers for cross-origin URLs in the allowlist', async () => {
+      setupInstrumentation({
+        propagateTraceHeaderCorsUrls: [/api\.example\.com/],
+      });
+      mockPropagation();
+
+      fetch('https://api.example.com/data');
+      await flushSpanEnd();
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(new Headers(init?.headers).get(TEST_HEADER)).toBe(TEST_VALUE);
+    });
+
+    it('injects trace headers into a Request object for same-origin requests', async () => {
+      mockPropagation();
+
+      fetch(new Request('http://localhost/api'));
+      await flushSpanEnd();
+
+      const [request] = mockFetch.mock.calls[0] as [Request];
+      expect(request.headers.get(TEST_HEADER)).toBe(TEST_VALUE);
+    });
+  });
+
+  // ─── Hooks ────────────────────────────────────────────────────────────────
+
+  describe('requestHook', () => {
+    it('calls requestHook with the span and request', async () => {
+      const hookFn = vi.fn();
+      setupInstrumentation({ requestHook: hookFn });
+
+      fetch('http://localhost/api', { method: 'GET' });
+      await flushSpanEnd();
+
+      expect(hookFn).toHaveBeenCalledOnce();
+
+      const firstCall = hookFn.mock.calls[0];
+      expect(firstCall).toBeDefined();
+
+      if (!firstCall) {
+        return;
+      }
+
+      expect(firstCall[1]).toBeInstanceOf(Object);
+    });
+
+    it('does not throw when requestHook throws', async () => {
+      setupInstrumentation({
+        requestHook: () => {
+          throw new Error('hook error');
+        },
+      });
+
+      await expect(
+        fetch('http://localhost/api').then(() => flushSpanEnd()),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('applyCustomAttributesOnSpan', () => {
+    it('allows the hook to set a custom attribute on the span', async () => {
+      setupInstrumentation({
+        applyCustomAttributesOnSpan: (span) => {
+          span.setAttribute('custom.attr', 'custom-value');
+        },
+      });
+
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.attributes['custom.attr']).toBe('custom-value');
+    });
+
+    it('does not throw when the hook throws', async () => {
+      setupInstrumentation({
+        applyCustomAttributesOnSpan: () => {
+          throw new Error('hook boom');
+        },
+      });
+
+      await expect(
+        fetch('http://localhost/api').then(() => flushSpanEnd()),
+      ).resolves.not.toThrow();
+
+      expect(getMainSpan()).toBeDefined();
+    });
+
+    it('allows the hook to set a custom attribute on error', async () => {
+      setupInstrumentation({
+        applyCustomAttributesOnSpan: (span, _req, result) => {
+          if (result instanceof Error) {
+            span.setAttribute('custom.error', result.message);
+          }
+        },
+      });
+      mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+      await expect(fetch('http://localhost/api')).rejects.toThrow();
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.attributes['custom.error']).toBe('Failed to fetch');
+    });
+  });
+
+  // ─── measureRequestSize ───────────────────────────────────────────────────
+
+  describe('measureRequestSize', () => {
+    it('sets http.request.body.size for string bodies', async () => {
+      setupInstrumentation({ measureRequestSize: true });
+
+      fetch('http://localhost/api', { method: 'POST', body: 'hello' }); // 5 bytes
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.attributes[ATTR_HTTP_REQUEST_BODY_SIZE]).toBe(5);
+    });
+
+    it('does not set http.request.body.size when there is no body', async () => {
+      setupInstrumentation({ measureRequestSize: true });
+
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      expect(
+        getMainSpan()?.attributes[ATTR_HTTP_REQUEST_BODY_SIZE],
+      ).toBeUndefined();
+    });
+
+    it('ends the span normally when body size measurement throws', async () => {
+      setupInstrumentation({ measureRequestSize: true });
+
+      const errorStream = new ReadableStream({
+        start(controller) {
+          controller.error(new Error('stream error'));
+        },
+      });
+
+      fetch('http://localhost/api', { method: 'POST', body: errorStream });
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.ended).toBe(true);
+      expect(
+        getMainSpan()?.attributes[ATTR_HTTP_REQUEST_BODY_SIZE],
+      ).toBeUndefined();
+    });
+  });
+
+  // ─── clearTimingResources ─────────────────────────────────────────────────
+
+  describe('clearTimingResources', () => {
+    it('calls performance.clearResourceTimings() after all spans complete', async () => {
+      const clearSpy = vi.spyOn(performance, 'clearResourceTimings');
+      setupInstrumentation({ clearTimingResources: true });
+
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      expect(clearSpy).toHaveBeenCalledOnce();
+    });
+
+    it('does not call performance.clearResourceTimings() when disabled', async () => {
+      const clearSpy = vi.spyOn(performance, 'clearResourceTimings');
+      setupInstrumentation({ clearTimingResources: false });
+
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      expect(clearSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Request object support ───────────────────────────────────────────────
+
+  describe('Request object support', () => {
+    it('handles a Request object as the first argument', async () => {
+      fetch(new Request('http://localhost/api', { method: 'PUT' }));
+      await flushSpanEnd();
+
+      const span = getMainSpan();
+      expect(span?.attributes[ATTR_HTTP_REQUEST_METHOD]).toBe('PUT');
+      expect(span?.attributes[ATTR_URL_FULL]).toBe('http://localhost/api');
+    });
+
+    it('merges init overrides on top of a Request object', async () => {
+      fetch(new Request('http://localhost/api', { method: 'GET' }), {
+        method: 'DELETE',
+      });
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.attributes[ATTR_HTTP_REQUEST_METHOD]).toBe(
+        'DELETE',
+      );
+    });
+  });
+
+  // ─── Response body handling ───────────────────────────────────────────────
+
+  describe('response body handling', () => {
+    it('ends the span when the response body stream errors mid-read', async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.error(new TypeError('stream error'));
+        },
+      });
+      mockFetch.mockResolvedValue(new Response(stream, { status: 200 }));
+
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.ended).toBe(true);
+    });
+
+    it('ends the span when response.clone() throws', async () => {
+      vi.spyOn(Response.prototype, 'clone').mockImplementationOnce(() => {
+        throw new Error('clone failed');
+      });
+
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.ended).toBe(true);
+    });
+
+    it('falls back to _endSpan when endSpanOnError itself throws', async () => {
+      mockFetch.mockRejectedValue(new TypeError('network error'));
+
+      let endSpanCallCount = 0;
+      // biome-ignore lint/suspicious/noExplicitAny: accessing private method for testing
+      vi.spyOn(instrumentation as any, '_endSpan').mockImplementation(() => {
+        endSpanCallCount++;
+        if (endSpanCallCount === 1) {
+          throw new Error('_endSpan failed');
+        }
+      });
+
+      await expect(fetch('http://localhost/api')).rejects.toThrow(
+        'network error',
+      );
+      await flushSpanEnd();
+
+      expect(endSpanCallCount).toBe(2);
+    });
+  });
+
+  // ─── Performance timing ───────────────────────────────────────────────────
+
+  describe('performance timing', () => {
+    it('collects matching resource timing entries via PerformanceObserver', async () => {
+      let capturedCallback: PerformanceObserverCallback | undefined;
+
+      class MockPerformanceObserver {
+        constructor(cb: PerformanceObserverCallback) {
+          capturedCallback = cb;
+        }
+        observe = vi.fn();
+        disconnect = vi.fn();
+      }
+      vi.stubGlobal('PerformanceObserver', MockPerformanceObserver);
+
+      setupInstrumentation();
+      fetch('http://localhost/api');
+
+      const fakeEntry = {
+        initiatorType: 'fetch',
+        name: 'http://localhost/api',
+        entryType: 'resource',
+      } as unknown as PerformanceResourceTiming;
+
+      capturedCallback?.(
+        {
+          getEntries: () => [fakeEntry],
+        } as unknown as PerformanceObserverEntryList,
+        {} as PerformanceObserver,
+      );
+
+      await flushSpanEnd();
+      expect(getMainSpan()?.ended).toBe(true);
+    });
+
+    it('emits a log with all timing attributes for a matched resource', async () => {
+      let capturedCallback: PerformanceObserverCallback | undefined;
+
+      class MockPerformanceObserver {
+        constructor(cb: PerformanceObserverCallback) {
+          capturedCallback = cb;
+        }
+        observe = vi.fn();
+        disconnect = vi.fn();
+      }
+      vi.stubGlobal('PerformanceObserver', MockPerformanceObserver);
+
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(0) // _prepareSpanData: spanStartPerfNow = 0
+        .mockReturnValue(1000); // _endSpan:         spanEndPerfNow = 1000
+
+      setupInstrumentation();
+      fetch('http://localhost/api');
+
+      capturedCallback?.(
+        {
+          getEntries: () => [
+            {
+              initiatorType: 'fetch',
+              name: 'http://localhost/api',
+              entryType: 'resource',
+              startTime: 10,
+              fetchStart: 10,
+              domainLookupStart: 20,
+              domainLookupEnd: 30,
+              connectStart: 30,
+              secureConnectionStart: 40,
+              connectEnd: 50,
+              requestStart: 50,
+              responseStart: 100,
+              responseEnd: 200,
+            } as unknown as PerformanceResourceTiming,
+          ],
+        } as unknown as PerformanceObserverEntryList,
+        {} as PerformanceObserver,
+      );
+
+      await flushSpanEnd();
+
+      const logRecords = getLogs();
+      expect(logRecords).toHaveLength(1);
+      const logRecord = logRecords[0];
+      expect(logRecord).toBeDefined();
+      if (!logRecord) {
+        return;
+      }
+
+      const attrs = logRecord.attributes;
+      expect(attrs['fetchStart']).toBe(10);
+      expect(attrs['domainLookupStart']).toBe(20);
+      expect(attrs['domainLookupEnd']).toBe(30);
+      expect(attrs['connectStart']).toBe(30);
+      expect(attrs['secureConnectionStart']).toBe(40);
+      expect(attrs['connectEnd']).toBe(50);
+      expect(attrs['requestStart']).toBe(50);
+      expect(attrs['responseStart']).toBe(100);
+      expect(attrs['responseEnd']).toBe(200);
+
+      const mainSpan = getMainSpan();
+      expect(logRecord.spanContext?.traceId).toBe(
+        mainSpan?.spanContext().traceId,
+      );
+      expect(logRecord.spanContext?.spanId).toBe(
+        mainSpan?.spanContext().spanId,
+      );
+    });
+
+    it('creates a CORS Preflight child span when two resource entries exist for a cross-origin URL', async () => {
+      let capturedCallback: PerformanceObserverCallback | undefined;
+
+      class MockPerformanceObserver {
+        constructor(cb: PerformanceObserverCallback) {
+          capturedCallback = cb;
+        }
+        observe = vi.fn();
+        disconnect = vi.fn();
+      }
+      vi.stubGlobal('PerformanceObserver', MockPerformanceObserver);
+
+      // Control performance.now() so entries fall within the span timing window
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(0) // _prepareSpanData: spanStartPerfNow = 0
+        .mockReturnValue(1000); // _endSpan:         spanEndPerfNow = 1000
+
+      const crossOriginUrl = 'http://api.example.com/data';
+      mockFetch.mockResolvedValue(makeResponse());
+      setupInstrumentation();
+      fetch(crossOriginUrl);
+
+      const makeEntry = (fetchStart: number, responseEnd: number) =>
+        ({
+          initiatorType: 'fetch',
+          name: crossOriginUrl,
+          entryType: 'resource',
+          startTime: fetchStart,
+          fetchStart,
+          domainLookupStart: fetchStart,
+          domainLookupEnd: fetchStart,
+          connectStart: fetchStart,
+          secureConnectionStart: 0,
+          connectEnd: fetchStart,
+          requestStart: fetchStart,
+          responseStart: responseEnd,
+          responseEnd,
+        }) as unknown as PerformanceResourceTiming;
+
+      capturedCallback?.(
+        {
+          getEntries: () => [makeEntry(1, 100), makeEntry(200, 400)],
+        } as unknown as PerformanceObserverEntryList,
+        {} as PerformanceObserver,
+      );
+
+      await flushSpanEnd();
+
+      const corsSpan = getSpans().find((s) => s.name === 'CORS Preflight');
+      expect(corsSpan).toBeDefined();
+      expect(corsSpan?.ended).toBe(true);
+      expect(getLogs()).toHaveLength(2);
+    });
+
+    it('does not emit a log when ignoreNetworkEvents is true', async () => {
+      let capturedCallback: PerformanceObserverCallback | undefined;
+
+      class MockPerformanceObserver {
+        constructor(cb: PerformanceObserverCallback) {
+          capturedCallback = cb;
+        }
+        observe = vi.fn();
+        disconnect = vi.fn();
+      }
+      vi.stubGlobal('PerformanceObserver', MockPerformanceObserver);
+
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(0) // _prepareSpanData: spanStartPerfNow = 0
+        .mockReturnValue(1000); // _endSpan:         spanEndPerfNow = 1000
+
+      setupInstrumentation({ ignoreNetworkEvents: true });
+      fetch('http://localhost/api');
+
+      capturedCallback?.(
+        {
+          getEntries: () => [
+            {
+              initiatorType: 'fetch',
+              name: 'http://localhost/api',
+              entryType: 'resource',
+              startTime: 10,
+              fetchStart: 10,
+              domainLookupStart: 20,
+              domainLookupEnd: 30,
+              connectStart: 30,
+              secureConnectionStart: 0,
+              connectEnd: 50,
+              requestStart: 50,
+              responseStart: 100,
+              responseEnd: 200,
+            } as unknown as PerformanceResourceTiming,
+          ],
+        } as unknown as PerformanceObserverEntryList,
+        {} as PerformanceObserver,
+      );
+
+      await flushSpanEnd();
+      expect(getLogs()).toHaveLength(0);
+    });
+
+    it('ends the span normally when getEntriesByType is unavailable', async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: simulating absent browser API
+      (performance as any).getEntriesByType = undefined;
+
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      expect(getMainSpan()?.ended).toBe(true);
+    });
+  });
+
+  // ─── Context propagation ──────────────────────────────────────────────────
+
+  describe('context propagation', () => {
+    it('creates a span and ends it after the response is consumed', async () => {
+      fetch('http://localhost/api');
+      await flushSpanEnd();
+
+      const span = getMainSpan();
+      expect(span).toBeDefined();
+
+      if (!span) {
+        return;
+      }
+
+      expect(span.ended).toBe(true);
+    });
+
+    it('wraps the fetch call inside context.with so the span is set', () => {
+      fetch('http://localhost/api');
+
+      // trace.getActiveSpan() relies on the context manager propagating context.
+      // With the NoopContextManager (default OTel API), this returns undefined.
+      // The important assertion is that the fetch is still instrumented.
+      expect(getSpans().length).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/packages/instrumentation/src/fetch/instrumentation.ts
+++ b/packages/instrumentation/src/fetch/instrumentation.ts
@@ -1,0 +1,457 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Attributes, Span } from '@opentelemetry/api';
+import {
+  context,
+  propagation,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+} from '@opentelemetry/api';
+import { SeverityNumber } from '@opentelemetry/api-logs';
+import {
+  InstrumentationBase,
+  safeExecuteInTheMiddle,
+} from '@opentelemetry/instrumentation';
+import { version } from '../../package.json' with { type: 'json' };
+import {
+  millisToHrTime,
+  perfNowToAbsoluteHrTime,
+} from '../utils/hrtime/index.ts';
+import { getFetchBodyLength } from '../utils/http/getFetchBodyLength.ts';
+import { normalizeHttpRequestMethod } from '../utils/http/normalizeHttpRequestMethod.ts';
+import {
+  getNetworkEventsAttributesFromResourceTiming,
+  getResource,
+} from '../utils/performance/index.ts';
+import {
+  isUrlIgnored,
+  parseUrl,
+  serverPortFromUrl,
+  shouldPropagateTraceHeaders,
+} from '../utils/url/index.ts';
+import {
+  ATTR_ERROR_TYPE,
+  ATTR_HTTP_REQUEST_BODY_SIZE,
+  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_HTTP_REQUEST_METHOD_ORIGINAL,
+  ATTR_HTTP_RESPONSE_STATUS_CODE,
+  ATTR_SERVER_ADDRESS,
+  ATTR_SERVER_PORT,
+  ATTR_URL_FULL,
+} from './semconv.ts';
+import type {
+  FetchError,
+  FetchInstrumentationConfig,
+  FetchResponse,
+  SpanData,
+} from './types.ts';
+
+// Wait for PerformanceObserver to collect resource timing info after the
+// response body is read — the "load" event fires before the observer does.
+const OBSERVER_WAIT_TIME_MS = 300;
+
+export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentationConfig> {
+  readonly component = 'fetch';
+  moduleName = this.component;
+
+  private _usedResources = new WeakSet<PerformanceResourceTiming>();
+  private _tasksCount = 0;
+
+  // `declare` prevents JS class field initializers from resetting these after
+  // the base class constructor calls enable().
+  private declare _isEnabled: boolean;
+  private declare _isFetchPatched: boolean;
+
+  constructor(config: FetchInstrumentationConfig = {}) {
+    super('@opentelemetry/browser-instrumentation/fetch', version, config);
+  }
+
+  protected override init() {
+    return [];
+  }
+
+  private _addChildSpan(
+    span: Span,
+    corsPreFlight: PerformanceResourceTiming,
+  ): void {
+    const startTime = perfNowToAbsoluteHrTime(corsPreFlight.fetchStart);
+    const childSpan = this.tracer.startSpan(
+      'CORS Preflight',
+      { startTime },
+      trace.setSpan(context.active(), span),
+    );
+    if (
+      !this.getConfig().ignoreNetworkEvents &&
+      corsPreFlight.startTime !== 0
+    ) {
+      this.logger.emit({
+        eventName: 'browser.fetch.cors_preflight_resource_timings',
+        context: trace.setSpan(context.active(), childSpan),
+        severityNumber: SeverityNumber.INFO,
+        attributes: getNetworkEventsAttributesFromResourceTiming(corsPreFlight),
+      });
+    }
+    childSpan.end(perfNowToAbsoluteHrTime(corsPreFlight.responseEnd));
+  }
+
+  private _addFinalSpanAttributes(span: Span, response: FetchResponse): void {
+    const parsedUrl = parseUrl(response.url);
+    span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, response.status);
+    span.setAttribute(ATTR_SERVER_ADDRESS, parsedUrl.hostname);
+    const port = serverPortFromUrl(parsedUrl);
+    if (port) {
+      span.setAttribute(ATTR_SERVER_PORT, port);
+    }
+  }
+
+  private _addHeaders(options: Request | RequestInit, spanUrl: string): void {
+    if (
+      !shouldPropagateTraceHeaders(
+        spanUrl,
+        this.getConfig().propagateTraceHeaderCorsUrls,
+      )
+    ) {
+      const headers: Partial<Record<string, unknown>> = {};
+      propagation.inject(context.active(), headers);
+      if (Object.keys(headers).length > 0) {
+        this._diag.debug('headers inject skipped due to CORS policy');
+      }
+      return;
+    }
+
+    if (options instanceof Request) {
+      propagation.inject(context.active(), options.headers, {
+        set: (h, k, v) => h.set(k, typeof v === 'string' ? v : String(v)),
+      });
+    } else {
+      const headers = new Headers(options.headers);
+      propagation.inject(context.active(), headers, {
+        set: (h, k, v) => h.set(k, typeof v === 'string' ? v : String(v)),
+      });
+      options.headers = headers;
+    }
+  }
+
+  private _clearResources(): void {
+    if (this._tasksCount === 0 && this.getConfig().clearTimingResources) {
+      performance.clearResourceTimings();
+      this._usedResources = new WeakSet<PerformanceResourceTiming>();
+    }
+  }
+
+  private _createSpan(
+    url: string,
+    options: Partial<Request | RequestInit> = {},
+  ): Span | undefined {
+    if (isUrlIgnored(url, this.getConfig().ignoreUrls)) {
+      this._diag.debug('ignoring span as url matches ignored url');
+      return;
+    }
+
+    const origMethod = options.method;
+    const normMethod = normalizeHttpRequestMethod(options.method ?? 'GET');
+    const attributes: Attributes = {
+      [ATTR_HTTP_REQUEST_METHOD]: normMethod,
+      [ATTR_URL_FULL]: url,
+    };
+    if (normMethod !== origMethod) {
+      attributes[ATTR_HTTP_REQUEST_METHOD_ORIGINAL] = origMethod;
+    }
+
+    return this.tracer.startSpan(normMethod, {
+      kind: SpanKind.CLIENT,
+      attributes,
+    });
+  }
+
+  private _findResourceAndAddNetworkEvents(
+    span: Span,
+    spanData: SpanData,
+    spanEndPerfNow: number,
+  ): void {
+    let resources: PerformanceResourceTiming[] = spanData.entries;
+    if (!resources.length) {
+      if (!performance.getEntriesByType) {
+        return;
+      }
+      resources = performance.getEntriesByType(
+        'resource',
+      ) as PerformanceResourceTiming[];
+    }
+
+    const resource = getResource(
+      spanData.spanUrl,
+      spanData.startPerfNow,
+      spanEndPerfNow,
+      resources,
+      this._usedResources,
+      'fetch',
+    );
+
+    if (resource.mainRequest) {
+      this._markResourceAsUsed(resource.mainRequest);
+      if (resource.corsPreFlightRequest) {
+        this._addChildSpan(span, resource.corsPreFlightRequest);
+        this._markResourceAsUsed(resource.corsPreFlightRequest);
+      }
+      if (
+        !this.getConfig().ignoreNetworkEvents &&
+        resource.mainRequest.startTime !== 0
+      ) {
+        this.logger.emit({
+          eventName: 'browser.fetch.resource_timings',
+          context: trace.setSpan(context.active(), span),
+          severityNumber: SeverityNumber.INFO,
+          attributes: getNetworkEventsAttributesFromResourceTiming(
+            resource.mainRequest,
+          ),
+        });
+      }
+    }
+  }
+
+  private _markResourceAsUsed(resource: PerformanceResourceTiming): void {
+    this._usedResources.add(resource);
+  }
+
+  private _endSpan(
+    span: Span,
+    spanData: SpanData,
+    response: FetchResponse,
+  ): void {
+    const endTime = millisToHrTime(Date.now());
+    const endPerfNow = performance.now();
+
+    this._addFinalSpanAttributes(span, response);
+
+    if (response.status >= 400) {
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      span.setAttribute(ATTR_ERROR_TYPE, String(response.status));
+    }
+
+    setTimeout(() => {
+      spanData.observer?.disconnect();
+      this._findResourceAndAddNetworkEvents(span, spanData, endPerfNow);
+      this._tasksCount--;
+      this._clearResources();
+      span.end(endTime);
+    }, OBSERVER_WAIT_TIME_MS);
+  }
+
+  private _patchConstructor(): (original: typeof fetch) => typeof fetch {
+    return (original) => {
+      const plugin = this;
+
+      return function patchedFetch(
+        this: typeof globalThis,
+        ...args: Parameters<typeof fetch>
+      ): Promise<Response> {
+        if (!plugin._isEnabled) {
+          return original.apply(this, args);
+        }
+
+        const url = parseUrl(
+          args[0] instanceof Request ? args[0].url : String(args[0]),
+        ).href;
+
+        // Merge Request + init so downstream code sees the final values.
+        let options: Request | RequestInit;
+        if (args[0] instanceof Request) {
+          options = args[1] != null ? new Request(args[0], args[1]) : args[0];
+        } else {
+          options = args[1] ?? {};
+        }
+
+        const createdSpan = plugin._createSpan(url, options);
+        if (!createdSpan) {
+          return original.apply(this, args);
+        }
+
+        const spanData = plugin._prepareSpanData(url);
+
+        if (plugin.getConfig().measureRequestSize) {
+          getFetchBodyLength(...args)
+            .then((bodyLength) => {
+              if (bodyLength != null) {
+                createdSpan.setAttribute(
+                  ATTR_HTTP_REQUEST_BODY_SIZE,
+                  bodyLength,
+                );
+              }
+            })
+            .catch((err) => {
+              plugin._diag.warn('getFetchBodyLength', err);
+            });
+        }
+
+        function endSpanOnError(span: Span, error: FetchError): void {
+          plugin._applyAttributesAfterFetch(span, options, error);
+          plugin._endSpan(span, spanData, {
+            status: error.status ?? 0,
+            statusText: error.message,
+            url,
+          });
+        }
+
+        function endSpanOnSuccess(span: Span, response: Response): void {
+          plugin._applyAttributesAfterFetch(span, options, response);
+          if (response.status >= 200 && response.status < 400) {
+            plugin._endSpan(span, spanData, response);
+          } else {
+            plugin._endSpan(span, spanData, {
+              status: response.status,
+              statusText: response.statusText,
+              url,
+            });
+          }
+        }
+
+        function onSuccess(span: Span, response: Response): Response {
+          try {
+            const resClone = response.clone();
+            const body = resClone.body;
+            if (body) {
+              const reader = body.getReader();
+              const read = (): void => {
+                reader.read().then(
+                  ({ done }) => {
+                    if (done) {
+                      endSpanOnSuccess(span, response);
+                    } else {
+                      read();
+                    }
+                  },
+                  (error: FetchError) => endSpanOnError(span, error),
+                );
+              };
+              read();
+            } else {
+              endSpanOnSuccess(span, response);
+            }
+          } catch (error) {
+            plugin._diag.error('Failed to read fetch response body', error);
+            plugin._endSpan(span, spanData, { status: 0, url });
+          }
+          return response;
+        }
+
+        function onError(span: Span, error: FetchError): never {
+          try {
+            endSpanOnError(span, error);
+          } catch (e) {
+            plugin._diag.error('Failed to end span on fetch error', e);
+            plugin._endSpan(span, spanData, { status: error.status ?? 0, url });
+          }
+
+          throw error;
+        }
+
+        return context.with(
+          trace.setSpan(context.active(), createdSpan),
+          () => {
+            plugin._callRequestHook(createdSpan, options);
+            plugin._addHeaders(options, url);
+            plugin._tasksCount++;
+            return original
+              .apply(
+                globalThis,
+                options instanceof Request ? [options] : [url, options],
+              )
+              .then(
+                (response: Response) => onSuccess(createdSpan, response),
+                (error: FetchError) => onError(createdSpan, error),
+              );
+          },
+        );
+      };
+    };
+  }
+
+  private _applyAttributesAfterFetch(
+    span: Span,
+    request: Request | RequestInit,
+    result: Response | FetchError,
+  ): void {
+    const hook = this.getConfig().applyCustomAttributesOnSpan;
+    if (!hook) {
+      return;
+    }
+    safeExecuteInTheMiddle(
+      () => hook(span, request, result),
+      (error) => {
+        if (error) {
+          this._diag.error('applyCustomAttributesOnSpan', error);
+        }
+      },
+      true,
+    );
+  }
+
+  private _callRequestHook(span: Span, request: Request | RequestInit): void {
+    const hook = this.getConfig().requestHook;
+    if (!hook) {
+      return;
+    }
+    safeExecuteInTheMiddle(
+      () => hook(span, request),
+      (error) => {
+        if (error) {
+          this._diag.error('requestHook', error);
+        }
+      },
+      true,
+    );
+  }
+
+  private _prepareSpanData(spanUrl: string): SpanData {
+    const startPerfNow = performance.now();
+    const entries: PerformanceResourceTiming[] = [];
+
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries() as PerformanceResourceTiming[]) {
+        if (entry.initiatorType === 'fetch' && entry.name === spanUrl) {
+          entries.push(entry);
+        }
+      }
+    });
+    observer.observe({ entryTypes: ['resource'] });
+
+    return { entries, observer, spanUrl, startPerfNow };
+  }
+
+  override enable(): void {
+    if (this._isEnabled) {
+      return;
+    }
+
+    if (this._isFetchPatched) {
+      this._diag.debug('fetch constructor already patched');
+      this._isEnabled = true;
+      return;
+    }
+
+    try {
+      this._wrap(globalThis, 'fetch', this._patchConstructor());
+      this._isFetchPatched = true;
+      this._isEnabled = true;
+    } catch (err) {
+      this._diag.warn(
+        'Failed to patch globalThis.fetch; instrumentation will not be enabled. ' +
+          'Another script may have locked globalThis.fetch via Object.defineProperty.',
+        err,
+      );
+    }
+  }
+
+  override disable(): void {
+    if (!this._isEnabled) {
+      return;
+    }
+    this._isEnabled = false;
+    this._usedResources = new WeakSet<PerformanceResourceTiming>();
+  }
+}

--- a/packages/instrumentation/src/fetch/semconv.ts
+++ b/packages/instrumentation/src/fetch/semconv.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export {
+  ATTR_ERROR_TYPE,
+  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_HTTP_REQUEST_METHOD_ORIGINAL,
+  ATTR_HTTP_RESPONSE_STATUS_CODE,
+  ATTR_SERVER_ADDRESS,
+  ATTR_SERVER_PORT,
+  ATTR_URL_FULL,
+} from '@opentelemetry/semantic-conventions';
+
+export const ATTR_HTTP_REQUEST_BODY_SIZE = 'http.request.body.size';

--- a/packages/instrumentation/src/fetch/types.ts
+++ b/packages/instrumentation/src/fetch/types.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Span } from '@opentelemetry/api';
+import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
+
+type PropagateTraceHeaderCorsUrl = string | RegExp;
+
+export type PropagateTraceHeaderCorsUrls =
+  | PropagateTraceHeaderCorsUrl
+  | PropagateTraceHeaderCorsUrl[];
+
+export type FetchCustomAttributeFunction = (
+  span: Span,
+  request: Request | RequestInit,
+  result: Response | FetchError,
+) => void;
+
+export type FetchRequestHookFunction = (
+  span: Span,
+  request: Request | RequestInit,
+) => void;
+
+export interface FetchInstrumentationConfig extends InstrumentationConfig {
+  /** Regularly clear timing resources to avoid the browser limit (chrome 250, safari 150). */
+  clearTimingResources?: boolean;
+  /** URLs that should receive trace headers even when origin doesn't match. */
+  propagateTraceHeaderCorsUrls?: PropagateTraceHeaderCorsUrls;
+  /** URLs matching any entry will not be traced. */
+  ignoreUrls?: Array<string | RegExp>;
+  /** Called to add custom attributes on the span after the fetch completes. */
+  applyCustomAttributesOnSpan?: FetchCustomAttributeFunction;
+  /** Called to add custom attributes or headers before the request is sent. */
+  requestHook?: FetchRequestHookFunction;
+  /** Skip adding network timing as span events. */
+  ignoreNetworkEvents?: boolean;
+  /** Measure outgoing request body size. */
+  measureRequestSize?: boolean;
+}
+
+/** Internal type for passing data between span creation and completion. */
+export interface SpanData {
+  entries: PerformanceResourceTiming[];
+  observer?: PerformanceObserver;
+  spanUrl: string;
+  /** performance.now() timestamp at span creation — same reference frame as PerformanceResourceTiming. */
+  startPerfNow: number;
+}
+
+/** Internal representation of a fetch error. */
+export interface FetchError {
+  status?: number;
+  message: string;
+}
+
+/** Internal representation of a completed fetch response. */
+export interface FetchResponse {
+  status: number;
+  statusText?: string;
+  url: string;
+}

--- a/packages/instrumentation/src/utils/hrtime/index.ts
+++ b/packages/instrumentation/src/utils/hrtime/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { millisToHrTime } from './millisToHrTime.ts';
+export { perfNowToAbsoluteHrTime } from './perfNowToAbsoluteHrTime.ts';

--- a/packages/instrumentation/src/utils/hrtime/millisToHrTime.test.ts
+++ b/packages/instrumentation/src/utils/hrtime/millisToHrTime.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { millisToHrTime } from './millisToHrTime.ts';
+
+describe('millisToHrTime', () => {
+  it('converts zero milliseconds', () => {
+    expect(millisToHrTime(0)).toEqual([0, 0]);
+  });
+
+  it('converts whole seconds', () => {
+    expect(millisToHrTime(2000)).toEqual([2, 0]);
+  });
+
+  it('converts milliseconds with a fractional second', () => {
+    expect(millisToHrTime(1500)).toEqual([1, 500_000_000]);
+  });
+
+  it('converts 1 millisecond', () => {
+    expect(millisToHrTime(1)).toEqual([0, 1_000_000]);
+  });
+
+  it('converts a large epoch-like value', () => {
+    // 1_700_000_000_000 ms = 1_700_000_000 s, 0 ns
+    const [secs, ns] = millisToHrTime(1_700_000_000_000);
+    expect(secs).toBe(1_700_000_000);
+    expect(ns).toBe(0);
+  });
+
+  it('handles sub-millisecond precision via rounding', () => {
+    // 1001.5 ms → 1 s + 1.5ms = 1 s + 1_500_000 ns
+    const [secs, ns] = millisToHrTime(1001.5);
+    expect(secs).toBe(1);
+    expect(ns).toBe(1_500_000);
+  });
+});

--- a/packages/instrumentation/src/utils/hrtime/millisToHrTime.ts
+++ b/packages/instrumentation/src/utils/hrtime/millisToHrTime.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { HrTime } from '@opentelemetry/api';
+
+export function millisToHrTime(millis: number): HrTime {
+  const secs = Math.floor(millis / 1000);
+  const ns = Math.round((millis - secs * 1000) * 1e6);
+  return [secs, ns];
+}

--- a/packages/instrumentation/src/utils/hrtime/perfNowToAbsoluteHrTime.test.ts
+++ b/packages/instrumentation/src/utils/hrtime/perfNowToAbsoluteHrTime.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { millisToHrTime } from './millisToHrTime.ts';
+import { perfNowToAbsoluteHrTime } from './perfNowToAbsoluteHrTime.ts';
+
+describe('perfNowToAbsoluteHrTime', () => {
+  it('adds performance.timeOrigin to the given perfNow value', () => {
+    const origin = 1_700_000_000_000;
+    vi.spyOn(performance, 'timeOrigin', 'get').mockReturnValue(origin);
+
+    const perfNow = 250;
+    const result = perfNowToAbsoluteHrTime(perfNow);
+    expect(result).toEqual(millisToHrTime(origin + perfNow));
+
+    vi.restoreAllMocks();
+  });
+
+  it('returns an absolute HrTime with seconds and nanoseconds', () => {
+    vi.spyOn(performance, 'timeOrigin', 'get').mockReturnValue(1_000_000);
+
+    const [secs, ns] = perfNowToAbsoluteHrTime(500);
+    expect(secs).toBe(1000); // (1_000_000 + 500) / 1000 = 1000.5 → floor = 1000
+    expect(ns).toBe(500_000_000); // 0.5 s = 500_000_000 ns
+
+    vi.restoreAllMocks();
+  });
+});

--- a/packages/instrumentation/src/utils/hrtime/perfNowToAbsoluteHrTime.ts
+++ b/packages/instrumentation/src/utils/hrtime/perfNowToAbsoluteHrTime.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { HrTime } from '@opentelemetry/api';
+import { millisToHrTime } from './millisToHrTime.ts';
+
+/** Converts a performance.now() value to an absolute wall-clock HrTime. */
+export function perfNowToAbsoluteHrTime(perfNow: number): HrTime {
+  return millisToHrTime(performance.timeOrigin + perfNow);
+}

--- a/packages/instrumentation/src/utils/http/getFetchBodyLength.test.ts
+++ b/packages/instrumentation/src/utils/http/getFetchBodyLength.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getFetchBodyLength } from './getFetchBodyLength.ts';
+
+describe('getFetchBodyLength', () => {
+  describe('with URL/string first arg', () => {
+    it('returns undefined when init has no body', async () => {
+      expect(await getFetchBodyLength('http://example.com')).toBeUndefined();
+      expect(
+        await getFetchBodyLength('http://example.com', {}),
+      ).toBeUndefined();
+    });
+
+    it('measures a string body', async () => {
+      const result = await getFetchBodyLength('http://example.com', {
+        body: 'hello',
+      });
+      expect(result).toBe(5);
+    });
+
+    it('measures a multi-byte string body', async () => {
+      // '€' is 3 bytes in UTF-8
+      const result = await getFetchBodyLength('http://example.com', {
+        body: '€',
+      });
+      expect(result).toBe(3);
+    });
+
+    it('measures a Blob body', async () => {
+      const blob = new Blob(['hello world']);
+      const result = await getFetchBodyLength('http://example.com', {
+        body: blob,
+      });
+      expect(result).toBe(11);
+    });
+
+    it('measures a URLSearchParams body', async () => {
+      const params = new URLSearchParams({ key: 'value' });
+      const result = await getFetchBodyLength('http://example.com', {
+        body: params,
+      });
+      expect(result).toBe(
+        new TextEncoder().encode(params.toString()).byteLength,
+      );
+    });
+
+    it('measures an ArrayBuffer body', async () => {
+      const buffer = new ArrayBuffer(16);
+      const result = await getFetchBodyLength('http://example.com', {
+        body: buffer,
+      });
+      expect(result).toBe(16);
+    });
+
+    it('measures a Uint8Array body', async () => {
+      const arr = new Uint8Array([1, 2, 3, 4, 5]);
+      const result = await getFetchBodyLength('http://example.com', {
+        body: arr,
+      });
+      expect(result).toBe(5);
+    });
+
+    it('measures a FormData body (key + value byte lengths)', async () => {
+      const form = new FormData();
+      form.append('key', 'value');
+      const result = await getFetchBodyLength('http://example.com', {
+        body: form,
+      });
+      // 'key'.length + 'value'.length = 3 + 5 = 8
+      expect(result).toBe(8);
+    });
+  });
+
+  describe('with URL object first arg', () => {
+    it('measures a string body', async () => {
+      const url = new URL('http://example.com');
+      const result = await getFetchBodyLength(url, { body: 'test' });
+      expect(result).toBe(4);
+    });
+  });
+
+  describe('with Request first arg', () => {
+    it('returns undefined for a GET request (no body)', async () => {
+      const req = new Request('http://example.com');
+      const result = await getFetchBodyLength(req);
+      expect(result).toBeUndefined();
+    });
+
+    it('measures a POST request body', async () => {
+      const req = new Request('http://example.com', {
+        method: 'POST',
+        body: 'hello',
+      });
+      const result = await getFetchBodyLength(req);
+      expect(result).toBe(5);
+    });
+  });
+});

--- a/packages/instrumentation/src/utils/http/getFetchBodyLength.ts
+++ b/packages/instrumentation/src/utils/http/getFetchBodyLength.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const TEXT_ENCODER = new TextEncoder();
+
+export async function getFetchBodyLength(
+  ...args: Parameters<typeof fetch>
+): Promise<number | undefined> {
+  if (args[0] instanceof URL || typeof args[0] === 'string') {
+    const init = args[1];
+
+    if (!init?.body) {
+      return undefined;
+    }
+
+    if (init.body instanceof ReadableStream) {
+      const { body, length } = await measureStreamNonDestructively(init.body);
+      init.body = body;
+      return length;
+    }
+
+    return getBodyLength(init.body);
+  }
+
+  const req = args[0];
+
+  // request.body is not yet Baseline (not supported in Mozilla).
+  // This guard is necessary to avoid errors in unsupported browsers
+  // eslint-disable-next-line baseline-js/use-baseline
+  if (!req?.body) {
+    return undefined;
+  }
+
+  const body = await req.clone().text();
+
+  return getByteLength(body);
+}
+
+async function measureStreamNonDestructively(
+  body: ReadableStream,
+): Promise<{ body: ReadableStream; length: number | undefined }> {
+  if (!body.getReader) {
+    return { body, length: undefined };
+  }
+  const chunks: Uint8Array[] = [];
+  const reader = body.getReader();
+  let next = await reader.read();
+
+  while (!next.done) {
+    chunks.push(next.value);
+    next = await reader.read();
+  }
+
+  const length = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  const newBody = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+
+  return { body: newBody, length };
+}
+
+function getBodyLength(
+  body: Exclude<BodyInit, ReadableStream>,
+): number | undefined {
+  if (typeof body === 'string') {
+    return getByteLength(body);
+  }
+
+  if (body instanceof Blob) {
+    return body.size;
+  }
+
+  if (body instanceof FormData) {
+    let size = 0;
+    for (const [key, value] of body.entries()) {
+      size += key.length;
+      size += value instanceof Blob ? value.size : (value as string).length;
+    }
+    return size;
+  }
+
+  if (body instanceof URLSearchParams) {
+    return getByteLength(body.toString());
+  }
+
+  if ('byteLength' in body && typeof body.byteLength === 'number') {
+    return body.byteLength;
+  }
+
+  return undefined;
+}
+
+function getByteLength(s: string): number {
+  return TEXT_ENCODER.encode(s).byteLength;
+}

--- a/packages/instrumentation/src/utils/http/index.ts
+++ b/packages/instrumentation/src/utils/http/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { getFetchBodyLength } from './getFetchBodyLength.ts';
+export { normalizeHttpRequestMethod } from './normalizeHttpRequestMethod.ts';

--- a/packages/instrumentation/src/utils/http/normalizeHttpRequestMethod.test.ts
+++ b/packages/instrumentation/src/utils/http/normalizeHttpRequestMethod.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { normalizeHttpRequestMethod } from './normalizeHttpRequestMethod.ts';
+
+const KNOWN_METHODS = [
+  'CONNECT',
+  'DELETE',
+  'GET',
+  'HEAD',
+  'OPTIONS',
+  'PATCH',
+  'POST',
+  'PUT',
+  'QUERY',
+  'TRACE',
+];
+
+describe('normalizeHttpRequestMethod', () => {
+  it.each(
+    KNOWN_METHODS,
+  )('returns %s uppercased for a known method', (method) => {
+    expect(normalizeHttpRequestMethod(method)).toBe(method);
+  });
+
+  it.each(
+    KNOWN_METHODS,
+  )('accepts lowercase and returns uppercase for %s', (method) => {
+    expect(normalizeHttpRequestMethod(method.toLowerCase())).toBe(method);
+  });
+
+  it('returns _OTHER for an unknown method', () => {
+    expect(normalizeHttpRequestMethod('BREW')).toBe('_OTHER');
+    expect(normalizeHttpRequestMethod('CUSTOM')).toBe('_OTHER');
+  });
+
+  it('handles mixed-case input for known methods', () => {
+    expect(normalizeHttpRequestMethod('Get')).toBe('GET');
+    expect(normalizeHttpRequestMethod('pAtCh')).toBe('PATCH');
+  });
+});

--- a/packages/instrumentation/src/utils/http/normalizeHttpRequestMethod.ts
+++ b/packages/instrumentation/src/utils/http/normalizeHttpRequestMethod.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const KNOWN_METHODS: Record<string, boolean> = {
+  CONNECT: true,
+  DELETE: true,
+  GET: true,
+  HEAD: true,
+  OPTIONS: true,
+  PATCH: true,
+  POST: true,
+  PUT: true,
+  QUERY: true,
+  TRACE: true,
+};
+
+export function normalizeHttpRequestMethod(method: string): string {
+  return method.toUpperCase() in KNOWN_METHODS
+    ? method.toUpperCase()
+    : '_OTHER';
+}

--- a/packages/instrumentation/src/utils/index.ts
+++ b/packages/instrumentation/src/utils/index.ts
@@ -5,3 +5,20 @@
 
 export { getElementCSSSelector } from './getElementCSSSelector.ts';
 export { getElementXPath } from './getElementXPath.ts';
+export { millisToHrTime, perfNowToAbsoluteHrTime } from './hrtime/index.ts';
+export {
+  getFetchBodyLength,
+  normalizeHttpRequestMethod,
+} from './http/index.ts';
+export {
+  getResource,
+  type PerformanceResourceTimingInfo,
+} from './performance/index.ts';
+export {
+  isUrlIgnored,
+  type PropagateTraceHeaderCorsUrls,
+  parseUrl,
+  serverPortFromUrl,
+  shouldPropagateTraceHeaders,
+  urlMatches,
+} from './url/index.ts';

--- a/packages/instrumentation/src/utils/performance/getNetworkEventsAttributesFromResourceTiming.test.ts
+++ b/packages/instrumentation/src/utils/performance/getNetworkEventsAttributesFromResourceTiming.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getNetworkEventsAttributesFromResourceTiming } from './getNetworkEventsAttributesFromResourceTiming.ts';
+
+const makeEntry = (
+  overrides: Partial<PerformanceResourceTiming>,
+): PerformanceResourceTiming =>
+  ({
+    fetchStart: 0,
+    domainLookupStart: 0,
+    domainLookupEnd: 0,
+    connectStart: 0,
+    secureConnectionStart: 0,
+    connectEnd: 0,
+    requestStart: 0,
+    responseStart: 0,
+    responseEnd: 0,
+    ...overrides,
+  }) as unknown as PerformanceResourceTiming;
+
+describe('getNetworkEventsAttributesFromResourceTiming', () => {
+  it('returns all nine timing fields from the entry', () => {
+    const entry = makeEntry({
+      fetchStart: 10,
+      domainLookupStart: 20,
+      domainLookupEnd: 30,
+      connectStart: 30,
+      secureConnectionStart: 40,
+      connectEnd: 50,
+      requestStart: 50,
+      responseStart: 100,
+      responseEnd: 200,
+      name: 'I should be ignored',
+    });
+
+    const attrs = getNetworkEventsAttributesFromResourceTiming(entry);
+
+    expect(attrs).toEqual({
+      fetchStart: 10,
+      domainLookupStart: 20,
+      domainLookupEnd: 30,
+      connectStart: 30,
+      secureConnectionStart: 40,
+      connectEnd: 50,
+      requestStart: 50,
+      responseStart: 100,
+      responseEnd: 200,
+    });
+  });
+});

--- a/packages/instrumentation/src/utils/performance/getNetworkEventsAttributesFromResourceTiming.ts
+++ b/packages/instrumentation/src/utils/performance/getNetworkEventsAttributesFromResourceTiming.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function getNetworkEventsAttributesFromResourceTiming(
+  resource: PerformanceResourceTiming,
+): Record<string, number> {
+  return {
+    fetchStart: resource.fetchStart,
+    domainLookupStart: resource.domainLookupStart,
+    domainLookupEnd: resource.domainLookupEnd,
+    connectStart: resource.connectStart,
+    secureConnectionStart: resource.secureConnectionStart,
+    connectEnd: resource.connectEnd,
+    requestStart: resource.requestStart,
+    responseStart: resource.responseStart,
+    responseEnd: resource.responseEnd,
+  };
+}

--- a/packages/instrumentation/src/utils/performance/getResource.test.ts
+++ b/packages/instrumentation/src/utils/performance/getResource.test.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getResource } from './getResource.ts';
+
+function makeEntry(
+  overrides: Partial<Record<string, unknown>> = {},
+): PerformanceResourceTiming {
+  return {
+    initiatorType: 'fetch',
+    name: 'http://localhost/api',
+    fetchStart: 100,
+    responseEnd: 200,
+    startTime: 100,
+    duration: 100,
+    entryType: 'resource',
+    transferSize: 0,
+    encodedBodySize: 0,
+    decodedBodySize: 0,
+    domainLookupStart: 0,
+    domainLookupEnd: 0,
+    connectStart: 0,
+    secureConnectionStart: 0,
+    connectEnd: 0,
+    requestStart: 0,
+    responseStart: 0,
+    redirectStart: 0,
+    redirectEnd: 0,
+    workerStart: 0,
+    nextHopProtocol: '',
+    toJSON: () => ({}),
+    ...overrides,
+  } as unknown as PerformanceResourceTiming;
+}
+
+describe('getResource', () => {
+  it('returns undefined mainRequest when no resources match', () => {
+    const result = getResource('http://localhost/api', 50, 300, []);
+    expect(result).toEqual({ mainRequest: undefined });
+  });
+
+  it('returns the single matching resource as mainRequest', () => {
+    const entry = makeEntry();
+    const result = getResource('http://localhost/api', 50, 300, [entry]);
+    expect(result.mainRequest).toBe(entry);
+    expect(result.corsPreFlightRequest).toBeUndefined();
+  });
+
+  it('excludes resources outside the span time window', () => {
+    const tooEarly = makeEntry({ fetchStart: 10, responseEnd: 40 });
+    const tooLate = makeEntry({ fetchStart: 400, responseEnd: 500 });
+    const result = getResource('http://localhost/api', 50, 300, [
+      tooEarly,
+      tooLate,
+    ]);
+    expect(result.mainRequest).toBeUndefined();
+  });
+
+  it('excludes resources already in ignoredResources', () => {
+    const entry = makeEntry();
+    const ignored = new WeakSet([entry]);
+    const result = getResource(
+      'http://localhost/api',
+      50,
+      300,
+      [entry],
+      ignored,
+    );
+    expect(result.mainRequest).toBeUndefined();
+  });
+
+  it('excludes resources with the wrong initiatorType', () => {
+    const entry = makeEntry({ initiatorType: 'xmlhttprequest' });
+    const result = getResource('http://localhost/api', 50, 300, [entry]);
+    expect(result.mainRequest).toBeUndefined();
+  });
+
+  it('uses a custom initiatorType when provided', () => {
+    const entry = makeEntry({ initiatorType: 'xmlhttprequest' });
+    const result = getResource(
+      'http://localhost/api',
+      50,
+      300,
+      [entry],
+      new WeakSet(),
+      'xmlhttprequest',
+    );
+    expect(result.mainRequest).toBe(entry);
+  });
+
+  it('resolves relative URLs via document.baseURI', () => {
+    const entry = makeEntry({ name: 'http://localhost/api' });
+    // '/api' resolves to 'http://localhost/api' with jsdom url: 'http://localhost/'
+    const result = getResource('/api', 50, 300, [entry]);
+    expect(result.mainRequest).toBe(entry);
+  });
+
+  it('picks the best of multiple same-origin matches', () => {
+    const first = makeEntry({ fetchStart: 100, responseEnd: 150 });
+    const second = makeEntry({ fetchStart: 110, responseEnd: 200 });
+    // With same origin, just returns filtered[0] (no CORS logic)
+    const result = getResource('http://localhost/api', 50, 300, [
+      first,
+      second,
+    ]);
+    expect(result.mainRequest).toBe(first);
+    expect(result.corsPreFlightRequest).toBeUndefined();
+  });
+
+  it('detects CORS preflight for cross-origin URLs', () => {
+    const preflight = makeEntry({
+      name: 'http://api.example.com/data',
+      fetchStart: 100,
+      responseEnd: 130,
+    });
+    const main = makeEntry({
+      name: 'http://api.example.com/data',
+      fetchStart: 140,
+      responseEnd: 250,
+    });
+    const result = getResource('http://api.example.com/data', 50, 300, [
+      preflight,
+      main,
+    ]);
+    expect(result.corsPreFlightRequest).toBe(preflight);
+    expect(result.mainRequest).toBe(main);
+  });
+});

--- a/packages/instrumentation/src/utils/performance/getResource.ts
+++ b/packages/instrumentation/src/utils/performance/getResource.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { parseUrl } from '../url/parseUrl.ts';
+
+export interface PerformanceResourceTimingInfo {
+  corsPreFlightRequest?: PerformanceResourceTiming;
+  mainRequest?: PerformanceResourceTiming;
+}
+
+function sortByFetchStart(
+  resources: PerformanceResourceTiming[],
+): PerformanceResourceTiming[] {
+  return resources.slice().sort((a, b) => a.fetchStart - b.fetchStart);
+}
+
+/**
+ * Filter resources matching the span URL and initiator type whose timing
+ * window overlaps with [spanStartPerfNow, spanEndPerfNow]. All times are in
+ * milliseconds relative to performance.timeOrigin (same reference frame as
+ * PerformanceResourceTiming timestamps).
+ */
+function filterResourcesForSpan(
+  spanUrl: string,
+  spanStartPerfNow: number,
+  spanEndPerfNow: number,
+  resources: PerformanceResourceTiming[],
+  ignoredResources: WeakSet<PerformanceResourceTiming>,
+  initiatorType: string,
+): PerformanceResourceTiming[] {
+  let filtered = resources.filter(
+    (r) =>
+      r.initiatorType.toLowerCase() === initiatorType &&
+      r.name === spanUrl &&
+      r.fetchStart >= spanStartPerfNow &&
+      r.responseEnd <= spanEndPerfNow,
+  );
+
+  if (filtered.length > 0) {
+    filtered = filtered.filter((r) => !ignoredResources.has(r));
+  }
+
+  return filtered;
+}
+
+/**
+ * Find the PerformanceResourceTiming entry (and any CORS preflight) that
+ * corresponds to the given fetch span.
+ *
+ * @param spanUrl - Resolved URL of the span.
+ * @param spanStartPerfNow - performance.now() at span creation.
+ * @param spanEndPerfNow - performance.now() at span end.
+ * @param resources - Available resource timing entries.
+ * @param ignoredResources - Entries already claimed by previous spans.
+ * @param initiatorType - Expected initiatorType (default: 'fetch').
+ */
+export function getResource(
+  spanUrl: string,
+  spanStartPerfNow: number,
+  spanEndPerfNow: number,
+  resources: PerformanceResourceTiming[],
+  ignoredResources: WeakSet<PerformanceResourceTiming> = new WeakSet(),
+  initiatorType = 'fetch',
+): PerformanceResourceTimingInfo {
+  const parsedUrl = parseUrl(spanUrl);
+  const resolvedUrl = parsedUrl.href;
+
+  const filtered = filterResourcesForSpan(
+    resolvedUrl,
+    spanStartPerfNow,
+    spanEndPerfNow,
+    resources,
+    ignoredResources,
+    initiatorType,
+  );
+
+  if (filtered.length === 0) {
+    return {
+      mainRequest: undefined,
+    };
+  }
+
+  if (filtered.length === 1) {
+    return {
+      mainRequest: filtered[0],
+    };
+  }
+
+  const sorted = sortByFetchStart(filtered);
+
+  if (parsedUrl.origin !== location.origin && sorted.length > 1) {
+    // biome-ignore lint/style/noNonNullAssertion: filtered.length > 1 is guaranteed above, so sorted[0] exists.
+    const firstResource: PerformanceResourceTiming = sorted[0]!;
+    let corsPreFlight: PerformanceResourceTiming | undefined = firstResource;
+
+    // biome-ignore lint/style/noNonNullAssertion: filtered.length > 1 is guaranteed above, so sorted[1] exists.
+    let main: PerformanceResourceTiming = sorted[1]!;
+    let bestGap: number | undefined;
+
+    /**
+     * Find the resource in `sorted` (already sorted by fetchStart) that best
+     * corresponds to the main request, skipping the CORS preflight at index 0.
+     * All times are in milliseconds relative to performance.timeOrigin.
+     */
+    for (let i = 1; i < sorted.length; i++) {
+      // biome-ignore lint/style/noNonNullAssertion: filtered.length > 1 is guaranteed above, so sorted[1] exists.
+      const r: PerformanceResourceTiming = sorted[i]!;
+      if (r.fetchStart >= firstResource.responseEnd) {
+        const gap = spanEndPerfNow - r.responseEnd;
+        if (bestGap === undefined || gap < bestGap) {
+          bestGap = gap;
+          main = r;
+        }
+      }
+    }
+
+    if (main.fetchStart < firstResource.responseEnd) {
+      main = firstResource;
+      corsPreFlight = undefined;
+    }
+
+    return {
+      corsPreFlightRequest: corsPreFlight,
+      mainRequest: main,
+    };
+  }
+
+  return {
+    mainRequest: filtered[0],
+  };
+}

--- a/packages/instrumentation/src/utils/performance/index.ts
+++ b/packages/instrumentation/src/utils/performance/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { getNetworkEventsAttributesFromResourceTiming } from './getNetworkEventsAttributesFromResourceTiming.ts';
+export {
+  getResource,
+  type PerformanceResourceTimingInfo,
+} from './getResource.ts';

--- a/packages/instrumentation/src/utils/test/index.ts
+++ b/packages/instrumentation/src/utils/test/index.ts
@@ -3,28 +3,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { logs } from '@opentelemetry/api-logs';
-import type { LogRecordProcessor } from '@opentelemetry/sdk-logs';
-import {
-  InMemoryLogRecordExporter,
-  LoggerProvider,
-  SimpleLogRecordProcessor,
-} from '@opentelemetry/sdk-logs';
-
-/**
- * setupTestLogExporter is a utility function that sets up a test log exporter for use in testing.
- * It returns an instance of InMemoryLogRecordExporter, hooked into a SimpleLogRecordProcessor, and a LoggerProvider.
- * */
-export const setupTestLogExporter = (
-  logProcessors: LogRecordProcessor[] = [],
-) => {
-  const memoryExporter = new InMemoryLogRecordExporter();
-  const logProvider = new LoggerProvider({
-    processors: [
-      ...logProcessors,
-      new SimpleLogRecordProcessor(memoryExporter),
-    ],
-  });
-  logs.setGlobalLoggerProvider(logProvider);
-  return memoryExporter;
-};
+export { setupTestLogExporter } from './setupTestLogExporter.ts';
+export { setupTestSpanExporter } from './setupTestSpanExporter.ts';

--- a/packages/instrumentation/src/utils/test/setupTestLogExporter.ts
+++ b/packages/instrumentation/src/utils/test/setupTestLogExporter.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { logs } from '@opentelemetry/api-logs';
+import type { LogRecordProcessor } from '@opentelemetry/sdk-logs';
+import {
+  InMemoryLogRecordExporter,
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+} from '@opentelemetry/sdk-logs';
+
+export const setupTestLogExporter = (
+  logProcessors: LogRecordProcessor[] = [],
+) => {
+  const memoryExporter = new InMemoryLogRecordExporter();
+  const logProvider = new LoggerProvider({
+    processors: [
+      ...logProcessors,
+      new SimpleLogRecordProcessor(memoryExporter),
+    ],
+  });
+  logs.setGlobalLoggerProvider(logProvider);
+  return memoryExporter;
+};

--- a/packages/instrumentation/src/utils/test/setupTestSpanExporter.ts
+++ b/packages/instrumentation/src/utils/test/setupTestSpanExporter.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { trace } from '@opentelemetry/api';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+
+export const setupTestSpanExporter = () => {
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+  trace.setGlobalTracerProvider(provider);
+  return exporter;
+};

--- a/packages/instrumentation/src/utils/url/index.ts
+++ b/packages/instrumentation/src/utils/url/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { isUrlIgnored } from './isUrlIgnored.ts';
+export { parseUrl } from './parseUrl.ts';
+export { serverPortFromUrl } from './serverPortFromUrl.ts';
+export {
+  type PropagateTraceHeaderCorsUrls,
+  shouldPropagateTraceHeaders,
+} from './shouldPropagateTraceHeaders.ts';
+export { urlMatches } from './urlMatches.ts';

--- a/packages/instrumentation/src/utils/url/isUrlIgnored.test.ts
+++ b/packages/instrumentation/src/utils/url/isUrlIgnored.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isUrlIgnored } from './isUrlIgnored.ts';
+
+describe('isUrlIgnored', () => {
+  it('returns false when ignoreUrls is undefined', () => {
+    expect(isUrlIgnored('http://example.com/api')).toBe(false);
+  });
+
+  it('returns false when ignoreUrls is empty', () => {
+    expect(isUrlIgnored('http://example.com/api', [])).toBe(false);
+  });
+
+  it('returns true for an exact string match', () => {
+    expect(
+      isUrlIgnored('http://example.com/health', ['http://example.com/health']),
+    ).toBe(true);
+  });
+
+  it('returns false for a non-matching string', () => {
+    expect(
+      isUrlIgnored('http://example.com/api', ['http://example.com/health']),
+    ).toBe(false);
+  });
+
+  it('returns true when a regexp matches', () => {
+    expect(isUrlIgnored('http://example.com/health/check', [/\/health/])).toBe(
+      true,
+    );
+  });
+
+  it('returns false when no regexp matches', () => {
+    expect(isUrlIgnored('http://example.com/api', [/\/health/])).toBe(false);
+  });
+
+  it('matches against any entry in a mixed list', () => {
+    const ignoreUrls = ['http://example.com/metrics', /\/health/];
+    expect(isUrlIgnored('http://example.com/metrics', ignoreUrls)).toBe(true);
+    expect(isUrlIgnored('http://example.com/health', ignoreUrls)).toBe(true);
+    expect(isUrlIgnored('http://example.com/api', ignoreUrls)).toBe(false);
+  });
+});

--- a/packages/instrumentation/src/utils/url/isUrlIgnored.ts
+++ b/packages/instrumentation/src/utils/url/isUrlIgnored.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { urlMatches } from './urlMatches.ts';
+
+export function isUrlIgnored(
+  url: string,
+  ignoreUrls?: Array<string | RegExp>,
+): boolean {
+  if (!ignoreUrls || ignoreUrls.length === 0) {
+    return false;
+  }
+
+  return ignoreUrls.some((p) => urlMatches(url, p));
+}

--- a/packages/instrumentation/src/utils/url/parseUrl.test.ts
+++ b/packages/instrumentation/src/utils/url/parseUrl.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseUrl } from './parseUrl.ts';
+
+describe('parseUrl', () => {
+  it('returns a URL object for an absolute URL', () => {
+    const result = parseUrl('http://example.com/path?q=1');
+    expect(result).toBeInstanceOf(URL);
+    expect(result.hostname).toBe('example.com');
+    expect(result.pathname).toBe('/path');
+    expect(result.search).toBe('?q=1');
+  });
+
+  it('resolves a relative URL against document.baseURI', () => {
+    const result = parseUrl('/api/data');
+    expect(result.hostname).toBe('localhost');
+    expect(result.pathname).toBe('/api/data');
+  });
+
+  it('preserves the origin for an absolute URL', () => {
+    const result = parseUrl('https://api.example.com/v2/users');
+    expect(result.origin).toBe('https://api.example.com');
+  });
+
+  it('returns the full href for an absolute URL', () => {
+    const url = 'http://example.com/path';
+    expect(parseUrl(url).href).toBe(url);
+  });
+});

--- a/packages/instrumentation/src/utils/url/parseUrl.ts
+++ b/packages/instrumentation/src/utils/url/parseUrl.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function parseUrl(url: string): URL {
+  return new URL(url, document.baseURI);
+}

--- a/packages/instrumentation/src/utils/url/serverPortFromUrl.test.ts
+++ b/packages/instrumentation/src/utils/url/serverPortFromUrl.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { serverPortFromUrl } from './serverPortFromUrl.ts';
+
+describe('serverPortFromUrl', () => {
+  it('returns the explicit port when set', () => {
+    expect(serverPortFromUrl(new URL('http://example.com:8080/api'))).toBe(
+      8080,
+    );
+  });
+
+  it('returns 443 for https with no explicit port', () => {
+    expect(serverPortFromUrl(new URL('https://example.com/api'))).toBe(443);
+  });
+
+  it('returns 80 for http with no explicit port', () => {
+    expect(serverPortFromUrl(new URL('http://example.com/api'))).toBe(80);
+  });
+
+  it('returns undefined for an unknown protocol with no explicit port', () => {
+    expect(
+      serverPortFromUrl(new URL('ftp://example.com/file')),
+    ).toBeUndefined();
+  });
+
+  it('returns explicit port over protocol default', () => {
+    expect(serverPortFromUrl(new URL('https://example.com:9443/api'))).toBe(
+      9443,
+    );
+  });
+});

--- a/packages/instrumentation/src/utils/url/serverPortFromUrl.ts
+++ b/packages/instrumentation/src/utils/url/serverPortFromUrl.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const DEFAULT_PORT: Record<string, string> = {
+  'https:': '443',
+  'http:': '80',
+};
+
+export function serverPortFromUrl(url: URL): number | undefined {
+  const port = Number(url.port || DEFAULT_PORT[url.protocol]);
+  return port && !Number.isNaN(port) ? port : undefined;
+}

--- a/packages/instrumentation/src/utils/url/shouldPropagateTraceHeaders.test.ts
+++ b/packages/instrumentation/src/utils/url/shouldPropagateTraceHeaders.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { shouldPropagateTraceHeaders } from './shouldPropagateTraceHeaders.ts';
+
+describe('shouldPropagateTraceHeaders', () => {
+  // jsdom URL is http://localhost/, so same-origin is http://localhost
+  it('returns true for a same-origin URL', () => {
+    expect(shouldPropagateTraceHeaders('http://localhost/api')).toBe(true);
+  });
+
+  it('returns false for a cross-origin URL with no allowlist', () => {
+    expect(shouldPropagateTraceHeaders('https://api.example.com/data')).toBe(
+      false,
+    );
+  });
+
+  it('returns false for a cross-origin URL not in the allowlist', () => {
+    expect(
+      shouldPropagateTraceHeaders('https://other.example.com/api', [
+        'https://allowed.example.com',
+      ]),
+    ).toBe(false);
+  });
+
+  it('returns true for a cross-origin URL matching a string in the allowlist', () => {
+    expect(
+      shouldPropagateTraceHeaders('https://api.example.com/data', [
+        'https://api.example.com/data',
+      ]),
+    ).toBe(true);
+  });
+
+  it('returns true for a cross-origin URL matching a regexp in the allowlist', () => {
+    expect(
+      shouldPropagateTraceHeaders('https://api.example.com/data', [
+        /api\.example\.com/,
+      ]),
+    ).toBe(true);
+  });
+
+  it('accepts a single string (not wrapped in an array)', () => {
+    expect(
+      shouldPropagateTraceHeaders(
+        'https://api.example.com/data',
+        'https://api.example.com/data',
+      ),
+    ).toBe(true);
+  });
+
+  it('accepts a single RegExp (not wrapped in an array)', () => {
+    expect(
+      shouldPropagateTraceHeaders(
+        'https://api.example.com/data',
+        /api\.example\.com/,
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/instrumentation/src/utils/url/shouldPropagateTraceHeaders.ts
+++ b/packages/instrumentation/src/utils/url/shouldPropagateTraceHeaders.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { parseUrl } from './parseUrl.ts';
+import { urlMatches } from './urlMatches.ts';
+
+export type PropagateTraceHeaderCorsUrls =
+  | string
+  | RegExp
+  | Array<string | RegExp>;
+
+export function shouldPropagateTraceHeaders(
+  spanUrl: string,
+  propagateTraceHeaderCorsUrls?: PropagateTraceHeaderCorsUrls,
+): boolean {
+  let corsUrls: Array<string | RegExp> = [];
+
+  if (propagateTraceHeaderCorsUrls) {
+    corsUrls = Array.isArray(propagateTraceHeaderCorsUrls)
+      ? propagateTraceHeaderCorsUrls
+      : [propagateTraceHeaderCorsUrls];
+  }
+
+  const parsed = parseUrl(spanUrl);
+  if (parsed.origin === location.origin) {
+    return true;
+  }
+
+  return corsUrls.some((p) => urlMatches(spanUrl, p));
+}

--- a/packages/instrumentation/src/utils/url/urlMatches.test.ts
+++ b/packages/instrumentation/src/utils/url/urlMatches.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { urlMatches } from './urlMatches.ts';
+
+describe('urlMatches', () => {
+  it('returns true for an exact string match', () => {
+    expect(urlMatches('http://example.com/api', 'http://example.com/api')).toBe(
+      true,
+    );
+  });
+
+  it('returns false for a non-matching string', () => {
+    expect(
+      urlMatches('http://example.com/api', 'http://example.com/other'),
+    ).toBe(false);
+  });
+
+  it('returns true when the regexp matches', () => {
+    expect(urlMatches('http://example.com/api/v1', /\/api\//)).toBe(true);
+  });
+
+  it('returns false when the regexp does not match', () => {
+    expect(urlMatches('http://example.com/health', /\/api\//)).toBe(false);
+  });
+
+  it('handles a regexp with anchors', () => {
+    expect(
+      urlMatches('http://example.com/api', /^http:\/\/example\.com\/api$/),
+    ).toBe(true);
+    expect(
+      urlMatches('http://example.com/api/v1', /^http:\/\/example\.com\/api$/),
+    ).toBe(false);
+  });
+});

--- a/packages/instrumentation/src/utils/url/urlMatches.ts
+++ b/packages/instrumentation/src/utils/url/urlMatches.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function urlMatches(url: string, pattern: string | RegExp): boolean {
+  return typeof pattern === 'string' ? url === pattern : pattern.test(url);
+}

--- a/packages/instrumentation/vitest.config.ts
+++ b/packages/instrumentation/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
         test: {
           name: 'unit',
           environment: 'jsdom',
+          environmentOptions: {
+            jsdom: { url: 'http://localhost/' },
+          },
           include: ['src/**/*.test.ts'],
           exclude: ['src/web-vitals/**'],
           browser: { enabled: false },


### PR DESCRIPTION
## Summary

This ports `@opentelemetry/instrumentation-fetch` from [opentelemetry-js](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch) into this browser-only repo, exposed as `@opentelemetry/browser-instrumentation/experimental/fetch`.

## Differences from the upstream package

### Behavioral

- **Stable semconv only.** Old attributes (`http.status_code`, `http.host`, `http.url`, `http.method`, `http.scheme`, `http.user_agent`, `component`, etc.) and the `semconvStabilityOptIn` config option have been removed. Only the stable set is emitted: `http.request.method`, `url.full`, `http.response.status_code`, `server.address`, `server.port`, `error.type`.

- **Network timing emitted as a log record instead of span events.** Upstream attaches one span event per timing field (`fetchStart`, `domainLookupStart`, `connectStart`, …) to the span. Here a single `LogRecord` is emitted with all timing values as attributes, correlated to the span via OTel context. The log carries an `eventName` (`browser.fetch.resource_timings` / `browser.fetch.cors_preflight_resource_timings`) and is skipped when `resource.startTime === 0`.

### Structural (no behavior difference in a browser)

- **Browser-only.** Node.js guards (`hasBrowserPerformanceAPI`, `typeof PerformanceObserver !== 'function'`) removed — this package never runs outside a browser.

- **No `@opentelemetry/sdk-trace-web` dependency.** `parseUrl`, `shouldPropagateTraceHeaders`, and `getResource` are ported locally under `src/utils/`. Logic is identical.

- **No `@opentelemetry/core` dependency.** `isUrlIgnored` and `millisToHrTime` are ported locally under `src/utils/`. Logic is identical.