### PR TITLE
fix(deps): pin fflate via @arethetypeswrong/core override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6945,7 +6945,7 @@
     },
     "packages/instrumentation": {
       "name": "@opentelemetry/browser-instrumentation",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "^0.218.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
   "peerDependencies": {
     "typescript": "^6.0.3"
   },
+  "overrides": {
+    "@arethetypeswrong/core": {
+      "fflate": "0.8.2"
+    }
+  },
   "workspaces": [
     "examples/*",
     "packages/*",


### PR DESCRIPTION
## Which problem is this PR solving?

`@arethetypeswrong/core` pulls in a newer transitive `fflate` version that's incompatible with our setup. Pinning it via npm `overrides` keeps `fflate` at a known-good version without waiting on an upstream release.

## Short description of the changes

- Add `overrides.@arethetypeswrong/core.fflate` = `0.8.2` in root `package.json`
- Refreshed `package-lock.json` to apply the override

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `npm install` resolves cleanly
- `npm run check` passes (pre-commit hook)

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated