### PR TITLE
fix(ci): prevent script injection in PR title workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -24,4 +24,6 @@ jobs:
       - run: npm ci
 
       - name: Validate PR title
-        run: echo "${{ github.event.pull_request.title }}" | npx commitlint
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | npx commitlint


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves the critical Scorecard `Dangerous-Workflow` code scanning alert (script injection) in `.github/workflows/pr-title.yml`.

The PR title validation step interpolated `${{ github.event.pull_request.title }}` directly into a `run:` shell command. GitHub expands `${{ }}` into the shell script source before bash executes, so a malicious PR title (for example `$(...)` or `"; ...; "`) would run as arbitrary code on the runner.

Fixes the alert at https://github.com/open-telemetry/opentelemetry-browser/security/code-scanning/9

## Short description of the changes

Pass the PR title through an `env:` variable and reference it as `"$PR_TITLE"` in the script. The value is then read by bash at runtime as data rather than being expanded into the script source, so its contents are never parsed as code. This is the remediation recommended by GitHub's script-injection hardening guide.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] commitlint still receives the PR title via stdin; behavior of the validation step is unchanged for legitimate titles.

## Checklist:

- [x] Followed the style guidelines of this project
