### PR TITLE
fix(errors): contain throwing LogRecordProcessor to prevent error-event loop

### DIFF
--- a/packages/instrumentation/src/errors/instrumentation.test.ts
+++ b/packages/instrumentation/src/errors/instrumentation.test.ts
@@ -58,6 +58,15 @@ const dispatchUnhandledRejection = (reason: Error | string) => {
   window.dispatchEvent(event);
 };
 
+// The instrumentation does not expose its diag logger or logger for testing,
+// so reach the internals through a single typed accessor rather than casting
+// in each test.
+const internals = (inst: ErrorsInstrumentation | undefined) =>
+  inst as unknown as {
+    _diag: { error: (...args: unknown[]) => void };
+    logger: { emit: (record: unknown) => void };
+  };
+
 describe('ErrorsInstrumentation', () => {
   let inMemoryExporter: InMemoryLogRecordExporter;
   let instrumentation: ErrorsInstrumentation | undefined;
@@ -243,6 +252,42 @@ describe('ErrorsInstrumentation', () => {
       expect(logs[0]?.attributes['app.custom.exception']).toBe(
         STRING_ERROR.toLocaleUpperCase(),
       );
+    });
+
+    it('should contain logger.emit failures to prevent an error-event feedback loop', () => {
+      // If logger.emit throws unguarded, the listener exception escapes
+      // dispatchEvent and is surfaced by the browser's "report the exception"
+      // algorithm as another 'error' event. That is the feedback-loop hazard
+      // this guard removes: safeExecuteInTheMiddle contains the throw and
+      // routes it to diag.error so it never escapes the listener in the first
+      // place. (In practice the HTML spec's "in error reporting mode" flag also
+      // keeps a real browser from refiring re-entrantly while reporting.)
+      instrumentation = new ErrorsInstrumentation({ enabled: false });
+      instrumentation.enable();
+
+      const accessor = internals(instrumentation);
+      const diagSpy = vi.spyOn(accessor._diag, 'error');
+      const emitSpy = vi
+        .spyOn(accessor.logger, 'emit')
+        .mockImplementation(() => {
+          throw new Error('processor exploded');
+        });
+
+      try {
+        // The feedback-loop guarantee is that the throw never escapes the
+        // listener; assert that directly, not just that it was logged.
+        expect(() =>
+          dispatchErrorEvent(new ValidationError('original')),
+        ).not.toThrow();
+
+        expect(diagSpy).toHaveBeenCalledWith(
+          'failed to emit exception log: original',
+          expect.any(Error),
+        );
+      } finally {
+        emitSpy.mockRestore();
+        diagSpy.mockRestore();
+      }
     });
 
     it('should still emit standard attributes when the hook throws', () => {

--- a/packages/instrumentation/src/errors/instrumentation.ts
+++ b/packages/instrumentation/src/errors/instrumentation.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Attributes } from '@opentelemetry/api';
-import type { AnyValueMap, LogRecord } from '@opentelemetry/api-logs';
+import type { AnyValueMap } from '@opentelemetry/api-logs';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import {
   InstrumentationBase,
@@ -69,26 +69,51 @@ export class ErrorsInstrumentation extends InstrumentationBase<ErrorsInstrumenta
       return;
     }
 
-    let errorAttributes: AnyValueMap;
-    if (typeof error === 'string') {
-      errorAttributes = { [ATTR_EXCEPTION_MESSAGE]: error };
-    } else {
-      errorAttributes = {
-        [ATTR_EXCEPTION_TYPE]: error.name,
-        [ATTR_EXCEPTION_MESSAGE]: error.message,
-        [ATTR_EXCEPTION_STACKTRACE]: error.stack,
-      };
-    }
+    this._emit(error);
+  }
 
-    const customAttributes = this._applyCustomAttributes(error);
+  // Build and emit the exception log inside a single guarded region so that
+  // nothing it touches can escape the global `error`/`unhandledrejection`
+  // listener and re-enter this handler via the browser's "report the
+  // exception" algorithm. That covers both a throwing LogRecordProcessor and
+  // a hostile `error` whose `name`/`message`/`stack` getters throw.
+  private _emit(error: Error | string): void {
+    // Captured before emit so the failure log can name the lost exception.
+    let message: string | undefined;
+    safeExecuteInTheMiddle(
+      () => {
+        let errorAttributes: AnyValueMap;
+        if (typeof error === 'string') {
+          message = error;
+          errorAttributes = { [ATTR_EXCEPTION_MESSAGE]: error };
+        } else {
+          message = error.message;
+          errorAttributes = {
+            [ATTR_EXCEPTION_TYPE]: error.name,
+            [ATTR_EXCEPTION_MESSAGE]: message,
+            [ATTR_EXCEPTION_STACKTRACE]: error.stack,
+          };
+        }
 
-    const logRecord: LogRecord = {
-      eventName: EXCEPTION_EVENT_NAME,
-      severityNumber: SeverityNumber.ERROR,
-      attributes: { ...errorAttributes, ...customAttributes },
-    };
-
-    this.logger.emit(logRecord);
+        this.logger.emit({
+          eventName: EXCEPTION_EVENT_NAME,
+          severityNumber: SeverityNumber.ERROR,
+          attributes: {
+            ...errorAttributes,
+            ...this._applyCustomAttributes(error),
+          },
+        });
+      },
+      (err) => {
+        if (err) {
+          this._diag.error(
+            `failed to emit exception log: ${message ?? '<unknown>'}`,
+            err,
+          );
+        }
+      },
+      true,
+    );
   }
 
   private _applyCustomAttributes(error: Error | string): Attributes {


### PR DESCRIPTION
## Which problem is this PR solving?

`ErrorsInstrumentation` emits its exception log from inside the global `error`/`unhandledrejection` listener. If a `LogRecordProcessor` throws during that emit, the exception escapes `dispatchEvent`. The browser then runs the HTML spec's "report the exception" algorithm, which surfaces another `error` event on `window`, re-entering this same listener. With a consistently throwing processor that re-entry can feed back on itself, so a misbehaving exporter can turn a single error into a storm.

## Short description of the changes

- Build and emit the exception log inside a single `safeExecuteInTheMiddle` region, so a throw from the logger pipeline is contained and routed to `diag.error` instead of escaping the listener.
- The attribute construction (`error.name`/`message`/`stack`) is inside the guarded region too, so even a hostile `error` with a throwing getter cannot escape.
- The failure diag log names the lost exception so a dropped emit is debuggable in isolation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- New unit test wires a throwing `logger.emit`, dispatches an `error` event, and asserts the throw never escapes `dispatchEvent` and is routed to `diag.error`.
- `npm run check` (tsc + eslint) clean; full vitest suite green (158 tests).

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
