### PR TITLE
fix(errors): contain throwing LogRecordProcessor to prevent error-event loop

### DIFF
--- a/packages/instrumentation/src/errors/instrumentation.test.ts
+++ b/packages/instrumentation/src/errors/instrumentation.test.ts
@@ -72,12 +72,16 @@ const dispatchUnhandledRejection = (
   window.dispatchEvent(event);
 };
 
-// The instrumentation does not expose its diag logger for testing, so reach
-// the internal `_diag` through a single typed accessor rather than casting in
-// each test.
+// The instrumentation does not expose its diag logger or logger for testing,
+// so reach the internals through a single typed accessor rather than casting
+// in each test.
 const internals = (inst: ErrorsInstrumentation | undefined) =>
   inst as unknown as {
-    _diag: { debug: (...args: unknown[]) => void };
+    _diag: {
+      debug: (...args: unknown[]) => void;
+      error: (...args: unknown[]) => void;
+    };
+    logger: { emit: (record: unknown) => void };
   };
 
 describe('ErrorsInstrumentation', () => {
@@ -380,6 +384,35 @@ describe('ErrorsInstrumentation', () => {
       const logs = getErrorLogs();
       expect(logs).toHaveLength(1);
       expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe('overridden');
+    });
+
+    it('should contain a throwing LogRecordProcessor and surface it via diag', () => {
+      instrumentation = new ErrorsInstrumentation({ enabled: false });
+      instrumentation.enable();
+
+      const accessor = internals(instrumentation);
+      const diagSpy = vi.spyOn(accessor._diag, 'error');
+      const emitSpy = vi
+        .spyOn(accessor.logger, 'emit')
+        .mockImplementation(() => {
+          throw new Error('processor exploded');
+        });
+
+      try {
+        dispatchErrorEvent(new ValidationError('boom'));
+
+        // Emit is attempted exactly once (no re-entry), no log escapes, and
+        // the failure is surfaced rather than swallowed.
+        expect(emitSpy).toHaveBeenCalledTimes(1);
+        expect(getErrorLogs()).toHaveLength(0);
+        expect(diagSpy).toHaveBeenCalledWith(
+          'failed to emit exception log',
+          expect.any(Error),
+        );
+      } finally {
+        emitSpy.mockRestore();
+        diagSpy.mockRestore();
+      }
     });
 
     it('should still emit standard attributes when the hook throws', () => {

--- a/packages/instrumentation/src/errors/instrumentation.test.ts
+++ b/packages/instrumentation/src/errors/instrumentation.test.ts
@@ -72,9 +72,9 @@ const dispatchUnhandledRejection = (
   window.dispatchEvent(event);
 };
 
-// The instrumentation does not expose its diag logger or logger for testing,
-// so reach the internals through a single typed accessor rather than casting
-// in each test.
+// The instrumentation does not expose its `_diag` or `logger` fields for
+// testing, so reach the internals through a single typed accessor rather than
+// casting in each test.
 const internals = (inst: ErrorsInstrumentation | undefined) =>
   inst as unknown as {
     _diag: {
@@ -386,35 +386,6 @@ describe('ErrorsInstrumentation', () => {
       expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe('overridden');
     });
 
-    it('should contain a throwing LogRecordProcessor and surface it via diag', () => {
-      instrumentation = new ErrorsInstrumentation({ enabled: false });
-      instrumentation.enable();
-
-      const accessor = internals(instrumentation);
-      const diagSpy = vi.spyOn(accessor._diag, 'error');
-      const emitSpy = vi
-        .spyOn(accessor.logger, 'emit')
-        .mockImplementation(() => {
-          throw new Error('processor exploded');
-        });
-
-      try {
-        dispatchErrorEvent(new ValidationError('boom'));
-
-        // Emit is attempted exactly once (no re-entry), no log escapes, and
-        // the failure is surfaced rather than swallowed.
-        expect(emitSpy).toHaveBeenCalledTimes(1);
-        expect(getErrorLogs()).toHaveLength(0);
-        expect(diagSpy).toHaveBeenCalledWith(
-          'failed to emit exception log',
-          expect.any(Error),
-        );
-      } finally {
-        emitSpy.mockRestore();
-        diagSpy.mockRestore();
-      }
-    });
-
     it('should still emit standard attributes when the hook throws', () => {
       instrumentation = new ErrorsInstrumentation({
         enabled: false,
@@ -434,6 +405,65 @@ describe('ErrorsInstrumentation', () => {
       expect(logs[0]?.attributes[ATTR_EXCEPTION_MESSAGE]).toBe(
         'Something happened!',
       );
+    });
+  });
+
+  describe('failure containment', () => {
+    beforeEach(() => {
+      instrumentation = new ErrorsInstrumentation({ enabled: false });
+      instrumentation.enable();
+    });
+
+    it('should contain a throwing LogRecordProcessor and surface it via diag', () => {
+      const accessor = internals(instrumentation);
+      const diagSpy = vi.spyOn(accessor._diag, 'error');
+      const emitSpy = vi
+        .spyOn(accessor.logger, 'emit')
+        .mockImplementation(() => {
+          throw new Error('processor exploded');
+        });
+
+      try {
+        // A throw escaping the listener would re-trigger 'error' and loop.
+        expect(() =>
+          dispatchErrorEvent(new ValidationError('boom')),
+        ).not.toThrow();
+
+        // Exactly once: the contained throw did not re-enter the listener.
+        expect(emitSpy).toHaveBeenCalledTimes(1);
+        expect(diagSpy).toHaveBeenCalledWith(
+          'failed to record exception',
+          expect.any(Error),
+        );
+      } finally {
+        emitSpy.mockRestore();
+        diagSpy.mockRestore();
+      }
+    });
+
+    it('should contain a rejection reason that throws while its properties are read', () => {
+      const diagSpy = vi.spyOn(internals(instrumentation)._diag, 'error');
+
+      // A promise can reject with any value. This one throws while its `stack`
+      // is read, exercising the extraction path before emit is ever reached.
+      const hostileReason = {} as Error;
+      Object.defineProperty(hostileReason, 'stack', {
+        get() {
+          throw new Error('stack getter exploded');
+        },
+      });
+
+      try {
+        expect(() => dispatchUnhandledRejection(hostileReason)).not.toThrow();
+
+        expect(getErrorLogs()).toHaveLength(0);
+        expect(diagSpy).toHaveBeenCalledWith(
+          'failed to record exception',
+          expect.any(Error),
+        );
+      } finally {
+        diagSpy.mockRestore();
+      }
     });
   });
 });

--- a/packages/instrumentation/src/errors/instrumentation.ts
+++ b/packages/instrumentation/src/errors/instrumentation.ts
@@ -97,32 +97,39 @@ export class ErrorsInstrumentation extends InstrumentationBase<ErrorsInstrumenta
       return;
     }
 
-    let errorAttributes: AnyValueMap;
-    if (typeof error === 'string') {
-      errorAttributes = { [ATTR_EXCEPTION_MESSAGE]: error };
-    } else {
-      errorAttributes = {
-        [ATTR_EXCEPTION_TYPE]: error.name,
-        [ATTR_EXCEPTION_MESSAGE]: error.message,
-        [ATTR_EXCEPTION_STACKTRACE]: error.stack,
-      };
-    }
+    // Capture as a const so the type narrowing survives into the closure below.
+    const capturedError = error;
 
-    const customAttributes = this._applyCustomAttributes(error);
-
-    const logRecord: LogRecord = {
-      eventName: EXCEPTION_EVENT_NAME,
-      severityNumber: SeverityNumber.ERROR,
-      attributes: { ...errorAttributes, ...customAttributes },
-    };
-
-    // A throwing LogRecordProcessor would otherwise let the exception escape
-    // this global error listener; contain it and surface the failure via diag.
+    // This runs inside a global error listener, so an escaping throw would
+    // re-trigger the listener and loop. Both attribute extraction (a rejection
+    // can carry a value whose `stack` getter throws) and emit (a broken
+    // LogRecordProcessor) can throw, so contain the whole path.
     safeExecuteInTheMiddle(
-      () => this.logger.emit(logRecord),
+      () => {
+        let errorAttributes: AnyValueMap;
+        if (typeof capturedError === 'string') {
+          errorAttributes = { [ATTR_EXCEPTION_MESSAGE]: capturedError };
+        } else {
+          errorAttributes = {
+            [ATTR_EXCEPTION_TYPE]: capturedError.name,
+            [ATTR_EXCEPTION_MESSAGE]: capturedError.message,
+            [ATTR_EXCEPTION_STACKTRACE]: capturedError.stack,
+          };
+        }
+
+        const customAttributes = this._applyCustomAttributes(capturedError);
+
+        const logRecord: LogRecord = {
+          eventName: EXCEPTION_EVENT_NAME,
+          severityNumber: SeverityNumber.ERROR,
+          attributes: { ...errorAttributes, ...customAttributes },
+        };
+
+        this.logger.emit(logRecord);
+      },
       (err) => {
         if (err) {
-          this._diag.error('failed to emit exception log', err);
+          this._diag.error('failed to record exception', err);
         }
       },
       true,

--- a/packages/instrumentation/src/errors/instrumentation.ts
+++ b/packages/instrumentation/src/errors/instrumentation.ts
@@ -116,7 +116,17 @@ export class ErrorsInstrumentation extends InstrumentationBase<ErrorsInstrumenta
       attributes: { ...errorAttributes, ...customAttributes },
     };
 
-    this.logger.emit(logRecord);
+    // A throwing LogRecordProcessor would otherwise let the exception escape
+    // this global error listener; contain it and surface the failure via diag.
+    safeExecuteInTheMiddle(
+      () => this.logger.emit(logRecord),
+      (err) => {
+        if (err) {
+          this._diag.error('failed to emit exception log', err);
+        }
+      },
+      true,
+    );
   }
 
   private _applyCustomAttributes(error: Error | string): Attributes {


### PR DESCRIPTION
## Which problem is this PR solving?

`ErrorsInstrumentation` records an exception log from inside its global `error` and `unhandledrejection` listeners. If anything on that path throws (a `LogRecordProcessor` throwing on emit, or reading attributes off a rejection value whose `stack` getter throws), the exception escapes the listener, gets reported as a new `error` event, and is picked up and re-emitted, risking a feedback loop.

## Short description of the changes

- Wrap attribute extraction and `this.logger.emit(logRecord)` together in `safeExecuteInTheMiddle` so neither a throwing processor nor a hostile error value can escape the listener.
- Surface the failure via `this._diag.error('failed to record exception', err)` instead of swallowing it.
- Add tests for both the throwing-processor and throwing-getter cases.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `@opentelemetry/browser-instrumentation` type-check and lint are clean, and its unit tests pass (182). Removing the containment makes the new tests fail (one dispatched error re-enters and emits twice), demonstrating the escape-and-re-emit path the fix closes.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
