### PR TITLE
chore: skip lifecycle scripts during npm ci in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           node-version-file: .nvmrc
           package-manager-cache: false
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - run: npm run build
 

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -27,7 +27,7 @@ jobs:
           node-version-file: .nvmrc
           package-manager-cache: false
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - run: npx turbo run build --filter=sandbox
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,6 @@ jobs:
           node-version-file: .nvmrc
           package-manager-cache: false
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - run: npm run lint:ci

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -21,7 +21,7 @@ jobs:
           node-version-file: .nvmrc
           package-manager-cache: false
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - name: Validate PR title
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,7 +47,7 @@ jobs:
           package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - run: npm run build
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           node-version-file: .nvmrc
           package-manager-cache: false
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - run: npm run build
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Short description of the changes

Run `npm ci --ignore-scripts` in CI to prevent install hooks from being executed in GitHub Actions. This improves supply chain security by avoiding the execution of dependency lifecycle scripts during automated builds.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ensure that all existing workflows continue to pass successfully.

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
