### PR TITLE
fix(sdk): use boolean private field and correct repository directory

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -22,9 +22,9 @@
   },
   "type": "module",
   "exports": {
+    ".": "./dist/start.js",
     "./logs": "./dist/logs.js",
-    "./traces": "./dist/traces.js",
-    ".": "./dist/start.js"
+    "./traces": "./dist/traces.js"
   },
   "sideEffects": false,
   "files": [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentelemetry/browser-sdk",
   "version": "0.1.0",
-  "private": "true",
+  "private": true,
   "description": "OpenTelemetry browser SDK package.",
   "keywords": [
     "opentelemetry",
@@ -18,7 +18,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/open-telemetry/opentelemetry-browser.git",
-    "directory": "packages/browser"
+    "directory": "packages/sdk"
   },
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Which problem is this PR solving?

The `packages/sdk/package.json` added in #288 has two metadata mistakes and one inconsistency:

- `private` is set to the string `"true"` instead of the boolean `true`. npm treats any truthy value as private so publishing is still blocked, but the value does not conform to the package.json schema.
- `repository.directory` points to `packages/browser`, a directory that does not exist in this repository.
- The `exports` map lists the root `"."` entry after the subpath entries.

## Short description of the changes

- Change `"private": "true"` to `"private": true`. The package is intentionally kept private for now; `publishConfig` is left in place for when it is ready to publish.
- Change `repository.directory` from `packages/browser` to `packages/sdk`.
- Reorder the `exports` map so the root `"."` entry comes first, matching common convention. This is cosmetic; resolution behavior is unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `npm run validate` passes (API compliance, web API baseline, package exports/publint, bundle size, module integrity)
- [x] `npm run lint` (biome, tsc, eslint) passes via the pre-commit hook

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added (not applicable, metadata-only change)
- [ ] Documentation has been updated (not applicable)