### PR TITLE
perf(instrumentation): declare package side-effect free for tree-shaking

### DIFF
--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -38,6 +38,7 @@
     "./experimental/user-action": "./dist/user-action/index.js",
     "./experimental/web-vitals": "./dist/web-vitals/index.js"
   },
+  "sideEffects": false,
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Which problem is this PR solving?

`@opentelemetry/browser-instrumentation` does not declare the `sideEffects` field in its package.json. Bundlers therefore keep modules they cannot prove pure, even when nothing from them is used. For example, a bare `import '@opentelemetry/browser-instrumentation/experimental/errors'` leaves residual code in the bundle that serves no purpose.

## Short description of the changes

Add `"sideEffects": false` to `packages/instrumentation/package.json`, matching the field already present in `packages/sdk/package.json`.

Safety was verified before adding the flag:

- Static audit of all non-test source modules: only imports, declarations, and exports. No module-scope function calls, IIFEs, or global (`window`/`document`) access at import time.
- The same audit on the built `dist` output: no top-level calls or global access.
- Empirical tree-shake test with rolldown: a bare side-effect import of an entry point bundled to 121 bytes before the flag and 0 bytes after. A normally-used import stayed byte-identical, so nothing functional is dropped.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] All 164 unit tests in the instrumentation package pass
- [x] `npm run validate` passes (API compliance, web API baseline, package exports/publint, bundle size, module integrity)
- [x] Rolldown bundle test described above confirms unused entry points are fully eliminated and used ones are unchanged

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added (not applicable, package metadata only)
- [ ] Documentation has been updated (not applicable)