### PR TITLE
feat(examples): wire browser-sdk/session processors into providers

### DIFF
--- a/examples/all-instrumentations/package.json
+++ b/examples/all-instrumentations/package.json
@@ -13,6 +13,7 @@
     "@opentelemetry/api-logs": "^0.219.0",
     "@opentelemetry/sdk-logs": "^0.219.0",
     "@opentelemetry/instrumentation": "^0.219.0",
-    "@opentelemetry/browser-instrumentation": "file:../../packages/instrumentation"
+    "@opentelemetry/browser-instrumentation": "file:../../packages/instrumentation",
+    "@opentelemetry/browser-sdk": "file:../../packages/sdk"
   }
 }

--- a/examples/all-instrumentations/src/main.ts
+++ b/examples/all-instrumentations/src/main.ts
@@ -5,6 +5,12 @@ import { NavigationTimingInstrumentation } from '@opentelemetry/browser-instrume
 import { ResourceTimingInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/resource-timing';
 import { UserActionInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/user-action';
 import { WebVitalsInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/web-vitals';
+import {
+  createDefaultSessionIdGenerator,
+  createLocalStorageSessionStore,
+  createSessionLogRecordProcessor,
+  createSessionManager,
+} from '@opentelemetry/browser-sdk/session';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import {
   ConsoleLogRecordExporter,
@@ -14,8 +20,23 @@ import {
 
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.VERBOSE);
 
+// ── Sessions ────────────────────────────────────────────────────────────────
+// The session processors must run BEFORE the export processors so the
+// session.id attribute is set on each log record before it is exported.
+const sessionManager = createSessionManager({
+  sessionIdGenerator: createDefaultSessionIdGenerator(),
+  sessionStore: createLocalStorageSessionStore(),
+  // 4h ceiling, 30min of inactivity rotates the session.
+  maxDuration: 4 * 60 * 60,
+  inactivityTimeout: 30 * 60,
+});
+await sessionManager.start();
+
 const loggerProvider = new LoggerProvider({
-  processors: [new SimpleLogRecordProcessor(new ConsoleLogRecordExporter())],
+  processors: [
+    createSessionLogRecordProcessor(sessionManager),
+    new SimpleLogRecordProcessor(new ConsoleLogRecordExporter()),
+  ],
 });
 
 logs.setGlobalLoggerProvider(loggerProvider);

--- a/examples/with-tracing/package.json
+++ b/examples/with-tracing/package.json
@@ -19,6 +19,7 @@
     "@opentelemetry/opentelemetry-browser-detector": "^0.219.0",
     "@opentelemetry/resources": "^2.8.0",
     "@opentelemetry/semantic-conventions": "^1.41.1",
-    "@opentelemetry/browser-instrumentation": "file:../../packages/instrumentation"
+    "@opentelemetry/browser-instrumentation": "file:../../packages/instrumentation",
+    "@opentelemetry/browser-sdk": "file:../../packages/sdk"
   }
 }

--- a/examples/with-tracing/src/main.ts
+++ b/examples/with-tracing/src/main.ts
@@ -3,6 +3,13 @@ import { logs } from '@opentelemetry/api-logs';
 import { NavigationTimingInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/navigation-timing';
 import { UserActionInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/user-action';
 import { WebVitalsInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/web-vitals';
+import {
+  createDefaultSessionIdGenerator,
+  createLocalStorageSessionStore,
+  createSessionLogRecordProcessor,
+  createSessionManager,
+  createSessionSpanProcessor,
+} from '@opentelemetry/browser-sdk/session';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
@@ -32,17 +39,35 @@ const detectedResources = detectResources({
 });
 resource = resource.merge(detectedResources);
 
+// --- Sessions ---
+// The session processors must run BEFORE the export processors so the
+// session.id attribute is set on each span / log record before it is exported.
+const sessionManager = createSessionManager({
+  sessionIdGenerator: createDefaultSessionIdGenerator(),
+  sessionStore: createLocalStorageSessionStore(),
+  // 4h ceiling, 30min of inactivity rotates the session.
+  maxDuration: 4 * 60 * 60,
+  inactivityTimeout: 30 * 60,
+});
+await sessionManager.start();
+
 // --- Event-based instrumentations (this repository) ---
 const logProvider = new LoggerProvider({
   resource,
-  processors: [new SimpleLogRecordProcessor(new ConsoleLogRecordExporter())],
+  processors: [
+    createSessionLogRecordProcessor(sessionManager),
+    new SimpleLogRecordProcessor(new ConsoleLogRecordExporter()),
+  ],
 });
 logs.setGlobalLoggerProvider(logProvider);
 
 // --- Span-based instrumentations (opentelemetry-js / opentelemetry-js-contrib) ---
 const provider = new WebTracerProvider({
   resource,
-  spanProcessors: [new SimpleSpanProcessor(new ConsoleSpanExporter())],
+  spanProcessors: [
+    createSessionSpanProcessor(sessionManager),
+    new SimpleSpanProcessor(new ConsoleSpanExporter()),
+  ],
 });
 provider.register();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",
         "@opentelemetry/browser-instrumentation": "file:../../packages/instrumentation",
+        "@opentelemetry/browser-sdk": "file:../../packages/sdk",
         "@opentelemetry/instrumentation": "^0.219.0",
         "@opentelemetry/sdk-logs": "^0.219.0"
       }
@@ -53,6 +54,7 @@
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",
         "@opentelemetry/browser-instrumentation": "file:../../packages/instrumentation",
+        "@opentelemetry/browser-sdk": "file:../../packages/sdk",
         "@opentelemetry/instrumentation": "^0.219.0",
         "@opentelemetry/instrumentation-fetch": "^0.219.0",
         "@opentelemetry/instrumentation-xml-http-request": "^0.219.0",


### PR DESCRIPTION
issue:
https://github.com/open-telemetry/opentelemetry-browser/issues/313

Follow-up to https://github.com/open-telemetry/opentelemetry-browser/pull/321. Adds the `@opentelemetry/browser-sdk/session` processors to
the two example apps so they emit `session.id` on every exported span / log,
mirroring the setup already in `sandbox/`.

- `examples/all-instrumentations`: prepends `createSessionLogRecordProcessor`
  to the `LoggerProvider` processors (logs only).
- `examples/with-tracing`: prepends `createSessionSpanProcessor` and
  `createSessionLogRecordProcessor` to the `WebTracerProvider` /
  `LoggerProvider` processors.

Both share the same `SessionManager` config used in the sandbox — 4h max
duration, 30min inactivity timeout, `LocalStorageSessionStore`,
`DefaultIdGenerator`.

## Test plan
- [ ] `npm install`
- [ ] `npm run check-types -w examples-all-instrumentations -w examples-with-tracing`
- [ ] `npm run dev -w examples-all-instrumentations` — confirm `session.id` on console-exported logs
- [ ] `npm run dev -w examples-with-tracing` — confirm `session.id` on console-exported spans and logs