### PR TITLE
docs(sdk): migrate sessions section from @opentelemetry/web-common README

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -339,6 +339,97 @@ Propagators to use to carry information to other services (like backend services
 
 Sampler to be used by traces to resolve if the Spans should be recorded or not.
 
+## Sessions
+
+Sessions correlate multiple traces, events and logs that happen within a given time period. Sessions are represented as span/log attributes prefixed with the `session.` namespace. For additional information, see [documentation in semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/session.md).
+
+The `@opentelemetry/browser-sdk/session` subpath provides a default implementation of managing sessions that:
+
+- abstracts persisting sessions across page loads, with a default implementation based on `LocalStorage`
+- abstracts generating session IDs
+- provides a mechanism for resetting the active session after a maximum defined duration
+- provides a mechanism for resetting the active session after a defined inactivity duration
+
+Example:
+
+```javascript
+import {
+  createDefaultSessionIdGenerator,
+  createLocalStorageSessionStore,
+  createSessionLogRecordProcessor,
+  createSessionManager,
+  createSessionSpanProcessor,
+} from '@opentelemetry/browser-sdk/session';
+
+// session manager
+const sessionManager = createSessionManager({
+  sessionIdGenerator: createDefaultSessionIdGenerator(),
+  sessionStore: createLocalStorageSessionStore(),
+  maxDuration: 4 * 60 * 60, // 4 hours
+  inactivityTimeout: 30 * 60, // 30 minutes
+});
+
+// restore or start the session
+await sessionManager.start();
+
+// configure tracer
+const tracerProvider = new WebTracerProvider({
+  spanProcessors: [
+    createSessionSpanProcessor(sessionManager),
+  ],
+});
+
+// configure logger
+const loggerProvider = new LoggerProvider({
+  processors: [
+    createSessionLogRecordProcessor(sessionManager),
+  ],
+});
+```
+
+The session processors must be registered **before** the export processors so the `session.id` attribute is set on each span / log record before it is exported.
+
+The above implementation can be customized by providing different implementations of `SessionStore` and `SessionIdGenerator`.
+
+### Observing sessions
+
+The `SessionManager` provides a mechanism for observing sessions. This is useful when other components should be notified when a session is started or ended.
+
+```javascript
+sessionManager.addObserver({
+  onSessionStarted: (newSession, previousSession) => {
+    console.log('Session started', newSession, previousSession);
+  },
+  onSessionEnded: (session) => {
+    console.log('Session ended', session);
+  },
+});
+```
+
+### Custom implementation of managing sessions
+
+If you require a completely custom solution for managing sessions, you can still use the processors that attach attributes to spans/logs by passing your own `getSessionId` implementation:
+
+```javascript
+const customSessionProvider = {
+  getSessionId: () => 'abcd1234',
+};
+
+// configure tracer
+const tracerProvider = new WebTracerProvider({
+  spanProcessors: [
+    createSessionSpanProcessor(customSessionProvider),
+  ],
+});
+
+// configure logger
+const loggerProvider = new LoggerProvider({
+  processors: [
+    createSessionLogRecordProcessor(customSessionProvider),
+  ],
+});
+```
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -353,6 +353,7 @@ The `@opentelemetry/browser-sdk/session` subpath provides a default implementati
 Example:
 
 ```javascript
+import { startBrowserSdk } from '@opentelemetry/browser-sdk';
 import {
   createDefaultSessionIdGenerator,
   createLocalStorageSessionStore,
@@ -372,18 +373,14 @@ const sessionManager = createSessionManager({
 // restore or start the session
 await sessionManager.start();
 
-// configure tracer
-const tracerProvider = new WebTracerProvider({
-  spanProcessors: [
-    createSessionSpanProcessor(sessionManager),
-  ],
-});
-
-// configure logger
-const loggerProvider = new LoggerProvider({
-  processors: [
-    createSessionLogRecordProcessor(sessionManager),
-  ],
+startBrowserSdk({
+  serviceName: 'my-service',
+  traces: {
+    processors: [createSessionSpanProcessor(sessionManager)],
+  },
+  logs: {
+    processors: [createSessionLogRecordProcessor(sessionManager)],
+  },
 });
 ```
 
@@ -415,18 +412,14 @@ const customSessionProvider = {
   getSessionId: () => 'abcd1234',
 };
 
-// configure tracer
-const tracerProvider = new WebTracerProvider({
-  spanProcessors: [
-    createSessionSpanProcessor(customSessionProvider),
-  ],
-});
-
-// configure logger
-const loggerProvider = new LoggerProvider({
-  processors: [
-    createSessionLogRecordProcessor(customSessionProvider),
-  ],
+startBrowserSdk({
+  serviceName: 'my-service',
+  traces: {
+    processors: [createSessionSpanProcessor(customSessionProvider)],
+  },
+  logs: {
+    processors: [createSessionLogRecordProcessor(customSessionProvider)],
+  },
 });
 ```
 


### PR DESCRIPTION
## Summary
Follow-up to #321. Migrates the `Sessions` documentation from
[`@opentelemetry/web-common`](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/web-common/README.md)
into the `@opentelemetry/browser-sdk` README