### PR TITLE
feat(sandbox): add exception event button

### DIFF
--- a/sandbox/src/app/actions.ts
+++ b/sandbox/src/app/actions.ts
@@ -67,7 +67,9 @@ export function createActions(tracer: Tracer, logger: Logger) {
 
   const exceptionEvent = () => {
     setTimeout(() => {
-      throw new Error('Demo exception event — captured by ErrorsInstrumentation');
+      throw new Error(
+        'Demo exception event — captured by ErrorsInstrumentation',
+      );
     }, 0);
   };
 

--- a/sandbox/src/app/actions.ts
+++ b/sandbox/src/app/actions.ts
@@ -63,6 +63,14 @@ export function createActions(tracer: Tracer, logger: Logger) {
     }
   };
 
+  // ── Event actions ────────────────────────────────────────────────────────────
+
+  const exceptionEvent = () => {
+    setTimeout(() => {
+      throw new Error('Demo exception event — captured by ErrorsInstrumentation');
+    }, 0);
+  };
+
   const navigation = () => {
     const routes = [
       '/home',
@@ -159,5 +167,6 @@ export function createActions(tracer: Tracer, logger: Logger) {
     logInfo,
     logWarn,
     logError,
+    exceptionEvent,
   };
 }

--- a/sandbox/src/app/components/ActionsPanel.tsx
+++ b/sandbox/src/app/components/ActionsPanel.tsx
@@ -121,6 +121,22 @@ export function ActionsPanel({ ready, act, sessionId }: ActionsPanelProps) {
           </button>
         </div>
       </article>
+
+      <article>
+        <header>
+          <strong>Events</strong>
+        </header>
+        <div className="btn-grid">
+          <button
+            type="button"
+            disabled={!ready}
+            onClick={() => act('exceptionEvent')}
+            className="btn-err"
+          >
+            💥 Exception
+          </button>
+        </div>
+      </article>
     </>
   );
 }

--- a/sandbox/src/otel.ts
+++ b/sandbox/src/otel.ts
@@ -4,6 +4,7 @@ import type { Tracer } from '@opentelemetry/api';
 import { trace } from '@opentelemetry/api';
 import type { Logger } from '@opentelemetry/api-logs';
 import { logs } from '@opentelemetry/api-logs';
+import { ErrorsInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/errors';
 import { NavigationTimingInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/navigation-timing';
 import { ResourceTimingInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/resource-timing';
 import { UserActionInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/user-action';
@@ -128,6 +129,7 @@ export async function initOtel(
   // ── Auto-instrumentations ───────────────────────────────────────────────────
   registerInstrumentations({
     instrumentations: [
+      new ErrorsInstrumentation(),
       new NavigationTimingInstrumentation(),
       new ResourceTimingInstrumentation({
         ignoreUrls: [config.tracesUrl, config.logsUrl],


### PR DESCRIPTION
## Summary

- Registers `ErrorsInstrumentation` in the sandbox SDK init so unhandled errors are automatically captured as exception log events
- Adds a new **Events** section to the actions panel with a single `💥 Exception` button that throws an unhandled error via `setTimeout`, triggering the instrumentation and producing a log record with `exception.type`, `exception.message`, and `exception.stacktrace`

## How it works

The button throws from inside a `setTimeout` callback so the error escapes React's event handling and reaches `window.onerror`, where `ErrorsInstrumentation` captures it and emits an OTel log record with `eventName: "exception"`.


## In the UI
<img width="2518" height="1220" alt="image" src="https://github.com/user-attachments/assets/c46d66bb-edc8-4685-a985-75e7cd778892" />

## Payload sent
<img width="1896" height="1168" alt="image" src="https://github.com/user-attachments/assets/bd69e918-07ff-402f-8bf6-02d66eec2cd5" />



