### PR TITLE
chore: fix workflow yaml formatting

### DIFF
--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-            persist-credentials: false
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '12 20 * * 3' # weekly at 20:12 (UTC) on Wednesday
+    - cron: 12 20 * * 3 # weekly at 20:12 (UTC) on Wednesday
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
## Which problem is this PR solving?

Two workflow files had cosmetic YAML issues: an over-indented `with:` key in the sandbox deploy job and a quoted cron expression in the scorecard schedule.

## Short description of the changes

- `deploy-sandbox.yml`: fix indentation of the `persist-credentials` key under `actions/checkout`.
- `scorecard.yml`: drop the quotes around the cron expression so it matches the style used elsewhere.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] YAML parses and the workflow definitions are unchanged in behavior (formatting only).
