### PR TITLE
ci: add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,35 @@
+name: "CodeQL Analysis"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  CodeQL-Build:
+    permissions:
+      security-events: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8533807ff379ac610d2b2c389c47e7c629d31d13 # v4.36.3
+        with:
+          languages: javascript
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@8533807ff379ac610d2b2c389c47e7c629d31d13 # v4.36.3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8533807ff379ac610d2b2c389c47e7c629d31d13 # v4.36.3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,12 +24,12 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8533807ff379ac610d2b2c389c47e7c629d31d13 # v4.36.3
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: javascript
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8533807ff379ac610d2b2c389c47e7c629d31d13 # v4.36.3
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8533807ff379ac610d2b2c389c47e7c629d31d13 # v4.36.3
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3


### PR DESCRIPTION
Closes #293

Adds a CodeQL analysis workflow mirroring the one in [opentelemetry-js](https://github.com/open-telemetry/opentelemetry-js/blob/main/.github/workflows/codeql-analysis.yml), with the following adaptations to stay consistent with this repo's existing workflows:

- `actions/checkout` pinned to v7 (matching `build.yml`)
- `merge_group` trigger added
- `github/codeql-action` updated to latest v4.36.3