### PR TITLE
feat:proposal(sdk): use crypto.randomUUID() for session ID generation

### DIFF
--- a/packages/sdk/src/session/DefaultIdGenerator.ts
+++ b/packages/sdk/src/session/DefaultIdGenerator.ts
@@ -6,22 +6,7 @@
 import type { SessionIdGenerator } from './types/SessionIdGenerator.ts';
 
 export class DefaultIdGenerator implements SessionIdGenerator {
-  generateSessionId = getIdGenerator(16);
-}
-
-const SHARED_CHAR_CODES_ARRAY = Array(32);
-function getIdGenerator(bytes: number): () => string {
-  return function generateId() {
-    for (let i = 0; i < bytes * 2; i++) {
-      SHARED_CHAR_CODES_ARRAY[i] = Math.floor(Math.random() * 16) + 48;
-      // valid hex characters in the range 48-57 and 97-102
-      if (SHARED_CHAR_CODES_ARRAY[i] >= 58) {
-        SHARED_CHAR_CODES_ARRAY[i] += 39;
-      }
-    }
-    return String.fromCharCode.apply(
-      null,
-      SHARED_CHAR_CODES_ARRAY.slice(0, bytes * 2),
-    );
-  };
+  generateSessionId(): string {
+    return crypto.randomUUID();
+  }
 }


### PR DESCRIPTION
Proposal to replace the custom `Math.random()`-based hex generator in `DefaultIdGenerator` with `crypto.randomUUID()`, producing standard UUID v4 session IDs.

This also switches to a cryptographically secure source of randomness and removes ~15 lines of custom ID generation code.
