### PR TITLE
fix(sdk): pass config to startBrowserSdk in quickStartBrowserSdk

### DIFF
--- a/packages/sdk/src/startBrowserSdk.test.ts
+++ b/packages/sdk/src/startBrowserSdk.test.ts
@@ -5,12 +5,43 @@
 
 import { diag, trace } from '@opentelemetry/api';
 import { logs } from '@opentelemetry/api-logs';
-import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import type { WebSdk } from './core/types.ts';
-import { startBrowserSdk } from './startBrowserSdk.ts';
+import { quickStartBrowserSdk, startBrowserSdk } from './startBrowserSdk.ts';
 
 // Arrange
 const SCHEDULE_DELAY = 10;
+
+/**
+ * Extracts the resource attributes from an OTLP/HTTP export request body
+ * (either `resourceSpans` for traces or `resourceLogs` for logs) into a
+ * simple key/value map so tests can assert on values like `service.name`.
+ */
+function resourceAttributesFromBody(
+  body: BodyInit | null | undefined,
+): Record<string, string> {
+  const text =
+    typeof body === 'string'
+      ? body
+      : new TextDecoder().decode(body as ArrayBuffer);
+  const payload = JSON.parse(text);
+  const resource =
+    payload.resourceSpans?.[0]?.resource ?? payload.resourceLogs?.[0]?.resource;
+  const attributes: Record<string, string> = {};
+  for (const attr of resource?.attributes ?? []) {
+    attributes[attr.key] = attr.value?.stringValue;
+  }
+  return attributes;
+}
 
 describe('startBrowserSdk', () => {
   const response = { ok: true, json: async () => ({ ok: true }) } as Response;
@@ -125,5 +156,107 @@ describe('startBrowserSdk', () => {
         },
       });
     });
+  });
+});
+
+describe('quickStartBrowserSdk', () => {
+  // NOTE: `status` is required so the OTLP exporter treats the response as a
+  // success; these tests flush via `shutdown()` and would otherwise surface
+  // the export failure.
+  const response = {
+    ok: true,
+    status: 200,
+    json: async () => ({ ok: true }),
+  } as Response;
+  // NOTE: the spies are installed per-test so this suite does not depend on
+  // the `startBrowserSdk` suite above, which shares the same `globalThis.fetch`
+  // spy and restores it in its `afterAll`.
+  let fetchSpy: MockInstance;
+  let consoleDirSpy: MockInstance;
+  let browserSdk: WebSdk;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(response);
+    consoleDirSpy = vi.spyOn(console, 'dir').mockImplementation(() => {});
+  });
+  afterEach(async () => {
+    // A test may already have shut the SDK down to flush its batch
+    // processors; ignore the resulting "already shutdown" error so the
+    // provider globals are always reset for the next test.
+    try {
+      await browserSdk?.shutdown();
+    } catch {
+      /* already shut down within the test */
+    }
+    fetchSpy.mockRestore();
+    consoleDirSpy.mockRestore();
+    logs.disable();
+    trace.disable();
+  });
+
+  it('should forward the export URL and headers to the exporters', async () => {
+    // Act
+    browserSdk = quickStartBrowserSdk({
+      exportUrl: 'http://otlp-signal-endpoint:4318',
+      exportHeaders: { bar: 'baz' },
+    });
+    logs.getLogger('logs-sdk-test').emit({ eventName: 'test' });
+    trace.getTracer('traces-sdk-test').startSpan('test').end();
+    // NOTE: quick start uses batch processors with default (long) delays,
+    // so we flush via shutdown instead of waiting for the scheduled export
+    await browserSdk.shutdown();
+
+    // Assert
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(
+      fetchSpy.mock.calls.find(
+        (args) => args[0] === 'http://otlp-signal-endpoint:4318/v1/logs',
+      ),
+    ).toBeDefined();
+    expect(
+      fetchSpy.mock.calls.find(
+        (args) => args[0] === 'http://otlp-signal-endpoint:4318/v1/traces',
+      ),
+    ).toBeDefined();
+    fetchSpy.mock.calls.forEach((args) => {
+      expect(args[1]).containSubset({
+        method: 'POST',
+        headers: { bar: 'baz' },
+      });
+    });
+  });
+
+  it('should propagate service name and version as resource attributes', async () => {
+    // Act
+    browserSdk = quickStartBrowserSdk({
+      exportUrl: 'http://otlp-signal-endpoint:4318',
+      serviceName: 'my-service',
+      serviceVersion: '1.2.3',
+    });
+    logs.getLogger('logs-sdk-test').emit({ eventName: 'test' });
+    trace.getTracer('traces-sdk-test').startSpan('test').end();
+    await browserSdk.shutdown();
+
+    // Assert: both the logs and traces payloads carry the resource attributes
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    fetchSpy.mock.calls.forEach((args) => {
+      const attributes = resourceAttributesFromBody(args[1]?.body);
+      expect(attributes['service.name']).toBe('my-service');
+      expect(attributes['service.version']).toBe('1.2.3');
+    });
+  });
+
+  it('should add console processors when logLevel is DEBUG', async () => {
+    // Act
+    browserSdk = quickStartBrowserSdk({
+      exportUrl: 'http://otlp-signal-endpoint:4318',
+      logLevel: 'DEBUG',
+    });
+    // Console exporters use SimpleProcessors, which export synchronously
+    logs.getLogger('logs-sdk-test').emit({ eventName: 'test' });
+    trace.getTracer('traces-sdk-test').startSpan('test').end();
+
+    // Assert: the console exporters write to `console.dir`
+    expect(consoleDirSpy).toHaveBeenCalled();
   });
 });

--- a/packages/sdk/src/startBrowserSdk.test.ts
+++ b/packages/sdk/src/startBrowserSdk.test.ts
@@ -173,11 +173,13 @@ describe('quickStartBrowserSdk', () => {
   // spy and restores it in its `afterAll`.
   let fetchSpy: MockInstance;
   let consoleDirSpy: MockInstance;
+  let diagDebugSpy: MockInstance;
   let browserSdk: WebSdk;
 
   beforeEach(() => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(response);
     consoleDirSpy = vi.spyOn(console, 'dir').mockImplementation(() => {});
+    diagDebugSpy = vi.spyOn(diag, 'debug');
   });
   afterEach(async () => {
     // A test may already have shut the SDK down to flush its batch
@@ -190,8 +192,26 @@ describe('quickStartBrowserSdk', () => {
     }
     fetchSpy.mockRestore();
     consoleDirSpy.mockRestore();
+    diagDebugSpy.mockRestore();
     logs.disable();
     trace.disable();
+  });
+
+  it('should not start when disabled by configuration', async () => {
+    // Act
+    browserSdk = quickStartBrowserSdk({
+      disabled: true,
+      exportUrl: 'http://otlp-signal-endpoint:4318',
+    });
+    logs.getLogger('logs-sdk-test').emit({ eventName: 'test' });
+    trace.getTracer('traces-sdk-test').startSpan('test').end();
+    // A started SDK would flush and export here; a disabled one must not
+    await browserSdk.shutdown();
+
+    // Assert
+    expect(diagDebugSpy).toHaveBeenCalled();
+    expect(diagDebugSpy.mock.lastCall?.[0]).toMatch(/Browser SDK disabled/);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it('should forward the export URL and headers to the exporters', async () => {

--- a/packages/sdk/src/startBrowserSdk.ts
+++ b/packages/sdk/src/startBrowserSdk.ts
@@ -93,5 +93,5 @@ export function quickStartBrowserSdk(config: QuickStartConfig) {
     };
   }
 
-  return startBrowserSdk();
+  return startBrowserSdk(sdkConfig);
 }


### PR DESCRIPTION
`quickStartBrowserSdk` built an sdkConfig object from the user's options but called `startBrowserSdk()` without passing it, so every option was silently dropped and the SDK always started with defaults.

This is a one-line fix + tests.