### PR TITLE
chore(sdk): enable publishing for browser-sdk

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       browser-instrumentation-release_created: ${{ steps.release.outputs['packages/instrumentation--release_created'] }}
+      browser-sdk-release_created: ${{ steps.release.outputs['packages/sdk--release_created'] }}
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
@@ -58,3 +59,7 @@ jobs:
       - name: Publish @opentelemetry/browser-instrumentation
         if: needs.release-please.outputs.browser-instrumentation-release_created == 'true'
         run: npm publish --workspace=packages/instrumentation --provenance --access public
+
+      - name: Publish @opentelemetry/browser-sdk
+        if: needs.release-please.outputs.browser-sdk-release_created == 'true'
+        run: npm publish --workspace=packages/sdk --provenance --access public

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,4 @@
 {
-  "packages/instrumentation": "0.5.2"
+  "packages/instrumentation": "0.5.2",
+  "packages/sdk": "0.1.0"
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@opentelemetry/browser-sdk",
   "version": "0.1.0",
-  "private": true,
   "description": "OpenTelemetry browser SDK package.",
   "keywords": [
     "opentelemetry",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,10 @@
     "packages/instrumentation": {
       "component": "browser-instrumentation",
       "changelog-path": "CHANGELOG.md"
+    },
+    "packages/sdk": {
+      "component": "browser-sdk",
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
Remove the `private` flag so the package can be published, and wire packages/sdk into release-please (config, manifest, and the CI publish step).

The first publish will be manual, so that trusted publisher can be configured. After that, release please should pick up subsequent releases.