### PR TITLE
chore(sdk): remove unused metrics dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1379,25 +1379,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.220.0.tgz",
-      "integrity": "sha512-Yqt3RBw/bRVncaE9qIIhk4WfjbAQqXuP9FgAaU+IKPndnLEp/cUqZlSC324+bpmduRz7DoTjig8Ub0PeILWXUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-metrics": "2.9.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
       "version": "0.220.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.220.0.tgz",
@@ -6037,11 +6018,9 @@
         "@opentelemetry/api-logs": "^0.220.0",
         "@opentelemetry/core": "^2.9.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.220.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "^0.220.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
         "@opentelemetry/resources": "^2.9.0",
         "@opentelemetry/sdk-logs": "^0.220.0",
-        "@opentelemetry/sdk-metrics": "^2.9.0",
         "@opentelemetry/sdk-trace": "^2.9.0"
       },
       "peerDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -56,11 +56,9 @@
     "@opentelemetry/api-logs": "^0.220.0",
     "@opentelemetry/core": "^2.9.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.220.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "^0.220.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
     "@opentelemetry/resources": "^2.9.0",
     "@opentelemetry/sdk-logs": "^0.220.0",
-    "@opentelemetry/sdk-metrics": "^2.9.0",
     "@opentelemetry/sdk-trace": "^2.9.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
`@opentelemetry/sdk-metrics` and `@opentelemetry/exporter-metrics-otlp-http` are not referenced anywhere in the package. The SDK only exports logs and traces. Dropping the deps to keep the install footprint minimal.