### PR TITLE
docs: add dedicated session management guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ For detailed configuration options, see the [instrumentation package README](./p
 
 For a more complete setup combining event-based instrumentations from this repository with span-based instrumentations from [opentelemetry-js](https://github.com/open-telemetry/opentelemetry-js) and [opentelemetry-js-contrib](https://github.com/open-telemetry/opentelemetry-js-contrib), see the [examples](./examples/) directory.
 
+## Documentation
+
+- [Session Management](./docs/session-management.md) — configuring and using the SDK's built-in session support.
+- [Browser Events](./docs/browser-observability-model.md) — catalog of browser telemetry events.
+- [Navigation event](./docs/navigation-event.md) — deep dive on the `browser.navigation` event.
+
 ## Browser Packages
 
 The following tables list browser-related packages across all OpenTelemetry JS repositories.

--- a/docs/session-management.md
+++ b/docs/session-management.md
@@ -1,3 +1,5 @@
+# Session Management
+
 ## Overview
 
 Sessions correlate multiple traces, events and logs that happen within a given time period.
@@ -94,26 +96,26 @@ interface Session {
 
 `createSessionManager` accepts a `SessionManagerConfig`:
 
-#### sessionIdGenerator
+### sessionIdGenerator
 
 A `SessionIdGenerator` (an object with `generateSessionId(): string`) responsible for producing
 new session IDs. Required. Use `createDefaultSessionIdGenerator()` for the built-in implementation,
 or provide your own — see [Custom implementations](#custom-implementations).
 
-#### sessionStore
+### sessionStore
 
 A `SessionStore` (an object with `save(session): Promise<void>` and `get(): Promise<Session |
 null>`) responsible for persisting the session across page loads. Required. Use
 `createLocalStorageSessionStore()` for the built-in implementation, or provide your own — see
 [Custom implementations](#custom-implementations).
 
-#### maxDuration
+### maxDuration
 
 Maximum duration of a session, in **seconds**. Optional — there is no built-in default. If
 omitted, the session is never reset due to elapsed time; it will only be reset by
 `inactivityTimeout` (if configured) or when explicitly recreated.
 
-#### inactivityTimeout
+### inactivityTimeout
 
 Maximum time without activity after which a session is reset, in **seconds**. Optional — there is
 no built-in default. If omitted, the session is never reset due to inactivity.
@@ -125,13 +127,13 @@ no built-in default. If omitted, the session is never reset due to inactivity.
 
 ## Default Implementations
 
-#### createDefaultSessionIdGenerator
+### createDefaultSessionIdGenerator
 
 Generates a 32-character hexadecimal ID using `Math.random()`. This is suitable as a correlation
 identifier but is **not cryptographically secure** and is not a UUID — do not use it as a security
 or authentication token.
 
-#### LocalStorageSessionStore
+### createLocalStorageSessionStore
 
 Persists the session as JSON under a single fixed key in `window.localStorage`. Because
 `localStorage` is shared by every tab and window open to the same origin, **all tabs on the same
@@ -186,7 +188,7 @@ a session starts or ends.
 
 ## Custom Implementations
 
-#### Custom SessionStore (per-tab sessions)
+### Custom SessionStore (per-tab sessions)
 
 The built-in `LocalStorageSessionStore` shares one session across every tab on the same origin. To
 scope sessions to a single tab instead, provide a `SessionStore` backed by `sessionStorage`, which
@@ -218,7 +220,7 @@ const sessionManager = createSessionManager({
 await sessionManager.start();
 ```
 
-#### Custom session provider (bypassing SessionManager)
+### Custom session provider (bypassing SessionManager)
 
 If you require a completely custom solution for managing sessions, you can skip `SessionManager`
 entirely and pass any object implementing `SessionProvider` directly to the processors:
@@ -251,7 +253,8 @@ Keep the following in mind when configuring session timeouts:
   inactivity window rather than continuing from where it left off, so a session can stay active
   longer than `inactivityTimeout` alone would suggest.
 - **Session IDs are not cryptographically secure.** The default ID generator uses `Math.random()`
-  and is intended only as a correlation identifier — see [DefaultIdGenerator](#defaultidgenerator).
+  and is intended only as a correlation identifier — see
+  [createDefaultSessionIdGenerator](#createdefaultsessionidgenerator).
 
 ## Related Links
 

--- a/docs/session-management.md
+++ b/docs/session-management.md
@@ -1,0 +1,263 @@
+## Overview
+
+Sessions correlate multiple traces, events and logs that happen within a given time period.
+Sessions are represented as span/log attributes prefixed with the `session.` namespace. For
+additional information, see the [documentation in semantic
+conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/session.md).
+
+A session is not tied to authentication or user identity — it's a time-boxed correlation ID that
+lets you group the telemetry produced by one visit (or one continuous stretch of activity) to your
+application.
+
+The `@opentelemetry/browser-sdk/session` subpath provides a default implementation of managing
+sessions that:
+
+- abstracts persisting sessions across page loads, with a default implementation based on
+  `LocalStorage`
+- abstracts generating session IDs
+- provides a mechanism for resetting the active session after a maximum defined duration
+- provides a mechanism for resetting the active session after a defined inactivity duration
+
+Use it when you want spans and log records emitted by the SDK's tracer/logger providers to carry a
+`session.id` attribute automatically, without having to thread a session identifier through your
+own application code.
+
+## Quick Start
+
+```javascript
+import { startBrowserSdk } from '@opentelemetry/browser-sdk';
+import {
+  createDefaultSessionIdGenerator,
+  createLocalStorageSessionStore,
+  createSessionLogRecordProcessor,
+  createSessionManager,
+  createSessionSpanProcessor,
+} from '@opentelemetry/browser-sdk/session';
+
+// session manager
+const sessionManager = createSessionManager({
+  sessionIdGenerator: createDefaultSessionIdGenerator(),
+  sessionStore: createLocalStorageSessionStore(),
+  maxDuration: 4 * 60 * 60, // 4 hours
+  inactivityTimeout: 30 * 60, // 30 minutes
+});
+
+// restore or start the session
+await sessionManager.start();
+
+startBrowserSdk({
+  serviceName: 'my-service',
+  traces: {
+    processors: [createSessionSpanProcessor(sessionManager)],
+  },
+  logs: {
+    processors: [createSessionLogRecordProcessor(sessionManager)],
+  },
+});
+```
+
+**Session processors must be registered before the export processors.** See [Registering session
+processors](#registering-session-processors) below for why, and for a full example with explicit
+provider setup.
+
+For the rest of the SDK's configuration (exporters, instrumentations, per-signal setup), see the
+[`@opentelemetry/browser-sdk` README](../packages/sdk/README.md).
+
+## Session Lifecycle
+
+A session is a small object with exactly two fields:
+
+```typescript
+interface Session {
+  id: string;
+  startTimestamp: number; // epoch milliseconds
+}
+```
+
+- **`sessionManager.start()`** — restores a session from the configured `sessionStore`, or starts
+  a new one if none is stored. It then arms the max-duration and inactivity timers.
+- **`sessionManager.getSessionId()` / `getSession()`** — return the current session, lazily
+  starting one if `start()` was never called. `getSession()` is also what drives inactivity
+  tracking: every call checks how long it has been since the last call, and rearms the inactivity
+  timer if more than 5 seconds have passed. In practice this means **"inactivity" measures how
+  long it has been since the last span was started or log record was emitted through the session
+  processors** — it is not based on raw browser input events (clicks, mouse movement, etc.).
+- **Session reset** — happens when either the `maxDuration` timer or the `inactivityTimeout` timer
+  fires. On reset, the current session ends (any registered `SessionObserver`s receive
+  `onSessionEnded`), a new session is created and persisted, and observers receive
+  `onSessionStarted` with both the new and previous session.
+- **`sessionManager.shutdown()`** — clears both timers so no further automatic resets happen. It
+  does **not** end the current session or clear it from storage; it only stops future
+  timer-driven resets. Call it when tearing down the SDK (e.g. in a single-page app teardown path).
+
+## Configuration
+
+`createSessionManager` accepts a `SessionManagerConfig`:
+
+#### sessionIdGenerator
+
+A `SessionIdGenerator` (an object with `generateSessionId(): string`) responsible for producing
+new session IDs. Required. Use `createDefaultSessionIdGenerator()` for the built-in implementation,
+or provide your own — see [Custom implementations](#custom-implementations).
+
+#### sessionStore
+
+A `SessionStore` (an object with `save(session): Promise<void>` and `get(): Promise<Session |
+null>`) responsible for persisting the session across page loads. Required. Use
+`createLocalStorageSessionStore()` for the built-in implementation, or provide your own — see
+[Custom implementations](#custom-implementations).
+
+#### maxDuration
+
+Maximum duration of a session, in **seconds**. Optional — there is no built-in default. If
+omitted, the session is never reset due to elapsed time; it will only be reset by
+`inactivityTimeout` (if configured) or when explicitly recreated.
+
+#### inactivityTimeout
+
+Maximum time without activity after which a session is reset, in **seconds**. Optional — there is
+no built-in default. If omitted, the session is never reset due to inactivity.
+
+> The `4 * 60 * 60` (4 hours) / `30 * 60` (30 minutes) values shown in the examples on this page
+> are simply the values this repository's own examples and sandbox use — they are not defaults
+> applied by `createSessionManager` or `SessionManager`. If you don't set `maxDuration` or
+> `inactivityTimeout`, the corresponding expiration mechanism is disabled entirely.
+
+## Default Implementations
+
+#### createDefaultSessionIdGenerator
+
+Generates a 32-character hexadecimal ID using `Math.random()`. This is suitable as a correlation
+identifier but is **not cryptographically secure** and is not a UUID — do not use it as a security
+or authentication token.
+
+#### LocalStorageSessionStore
+
+Persists the session as JSON under a single fixed key in `window.localStorage`. Because
+`localStorage` is shared by every tab and window open to the same origin, **all tabs on the same
+origin share one session** — this is "one session per browser origin," not "one session per tab."
+If you need per-tab sessions, provide a custom `SessionStore` backed by `sessionStorage` instead
+(see [Custom implementations](#custom-implementations)). The store is a safe no-op in environments
+without `localStorage` (e.g. during server-side rendering).
+
+## Registering Session Processors
+
+`createSessionSpanProcessor` and `createSessionLogRecordProcessor` add the `session.id` attribute
+to spans and log records respectively, by reading the current session ID from any object that
+implements `SessionProvider` (`getSessionId(): string | null`) — typically a `SessionManager`.
+
+As in the codebase's own [sandbox app](../sandbox/src/otel.ts), register the session processors
+**before** the export processors:
+
+```javascript
+const spanProcessors = [
+  createSessionSpanProcessor(sessionManager),
+  new BatchSpanProcessor({ exporter: traceExporter }),
+];
+
+const logProcessors = [
+  createSessionLogRecordProcessor(sessionManager),
+  new BatchLogRecordProcessor({ exporter: logExporter }),
+];
+```
+
+Processors run in registration order, so putting the session processor first guarantees
+`session.id` is already set on the span/log record by the time the export processor picks it up.
+If the export processor ran first, exported telemetry could be missing the attribute.
+
+## Observing Sessions
+
+`SessionManager` implements `SessionPublisher`, so you can register observers to be notified when
+a session starts or ends:
+
+```javascript
+sessionManager.addObserver({
+  onSessionStarted: (newSession, previousSession) => {
+    console.log('Session started', newSession, previousSession);
+  },
+  onSessionEnded: (session) => {
+    console.log('Session ended', session);
+  },
+});
+```
+
+Multiple observers can be registered; each is called synchronously in registration order whenever
+a session starts or ends.
+
+## Custom Implementations
+
+#### Custom SessionStore (per-tab sessions)
+
+The built-in `LocalStorageSessionStore` shares one session across every tab on the same origin. To
+scope sessions to a single tab instead, provide a `SessionStore` backed by `sessionStorage`, which
+is tab-scoped by design:
+
+```javascript
+import { createDefaultSessionIdGenerator, createSessionManager } from '@opentelemetry/browser-sdk/session';
+
+const SESSION_STORAGE_KEY = 'otel-session';
+
+const tabScopedSessionStore = {
+  save(session) {
+    sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
+    return Promise.resolve();
+  },
+  get() {
+    const data = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    return Promise.resolve(data ? JSON.parse(data) : null);
+  },
+};
+
+const sessionManager = createSessionManager({
+  sessionIdGenerator: createDefaultSessionIdGenerator(),
+  sessionStore: tabScopedSessionStore,
+  maxDuration: 4 * 60 * 60,
+  inactivityTimeout: 30 * 60,
+});
+
+await sessionManager.start();
+```
+
+#### Custom session provider (bypassing SessionManager)
+
+If you require a completely custom solution for managing sessions, you can skip `SessionManager`
+entirely and pass any object implementing `SessionProvider` directly to the processors:
+
+```javascript
+const customSessionProvider = {
+  getSessionId: () => 'abcd1234',
+};
+
+startBrowserSdk({
+  serviceName: 'my-service',
+  traces: {
+    processors: [createSessionSpanProcessor(customSessionProvider)],
+  },
+  logs: {
+    processors: [createSessionLogRecordProcessor(customSessionProvider)],
+  },
+});
+```
+
+## Known Limitations
+
+Keep the following in mind when configuring session timeouts:
+
+- **`maxDuration` values longer than ~24.8 days are not fully honored.** This is a limit of the
+  browser's timer API — a session configured with a longer `maxDuration` will still be reset at
+  roughly the 24.8-day mark.
+- **Reopening a previously closed tab restarts the inactivity countdown.** If `inactivityTimeout`
+  is set, resuming a session (for example after closing and reopening the tab) starts a fresh
+  inactivity window rather than continuing from where it left off, so a session can stay active
+  longer than `inactivityTimeout` alone would suggest.
+- **Session IDs are not cryptographically secure.** The default ID generator uses `Math.random()`
+  and is intended only as a correlation identifier — see [DefaultIdGenerator](#defaultidgenerator).
+
+## Related Links
+
+- [`@opentelemetry/browser-sdk` README](../packages/sdk/README.md) — full SDK setup, per-signal
+  configuration, and the quick-reference version of this content.
+- [Session semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/session.md)
+- [Browser Events](browser-observability-model.md) — catalog of browser telemetry events emitted
+  alongside sessions.
+- Source implementation: [`packages/sdk/src/session`](https://github.com/open-telemetry/opentelemetry-browser/tree/main/packages/sdk/src/session)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -386,42 +386,7 @@ startBrowserSdk({
 
 The session processors must be registered **before** the export processors so the `session.id` attribute is set on each span / log record before it is exported.
 
-The above implementation can be customized by providing different implementations of `SessionStore` and `SessionIdGenerator`.
-
-### Observing sessions
-
-The `SessionManager` provides a mechanism for observing sessions. This is useful when other components should be notified when a session is started or ended.
-
-```javascript
-sessionManager.addObserver({
-  onSessionStarted: (newSession, previousSession) => {
-    console.log('Session started', newSession, previousSession);
-  },
-  onSessionEnded: (session) => {
-    console.log('Session ended', session);
-  },
-});
-```
-
-### Custom implementation of managing sessions
-
-If you require a completely custom solution for managing sessions, you can still use the processors that attach attributes to spans/logs by passing your own `getSessionId` implementation:
-
-```javascript
-const customSessionProvider = {
-  getSessionId: () => 'abcd1234',
-};
-
-startBrowserSdk({
-  serviceName: 'my-service',
-  traces: {
-    processors: [createSessionSpanProcessor(customSessionProvider)],
-  },
-  logs: {
-    processors: [createSessionLogRecordProcessor(customSessionProvider)],
-  },
-});
-```
+For session lifecycle details, configuration reference, observing sessions, custom `SessionStore`/`SessionIdGenerator` implementations, and known limitations, see [Session Management](../../docs/session-management.md).
 
 ## Useful links
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -341,16 +341,8 @@ Sampler to be used by traces to resolve if the Spans should be recorded or not.
 
 ## Sessions
 
-Sessions correlate multiple traces, events and logs that happen within a given time period. Sessions are represented as span/log attributes prefixed with the `session.` namespace. For additional information, see [documentation in semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/session.md).
-
-The `@opentelemetry/browser-sdk/session` subpath provides a default implementation of managing sessions that:
-
-- abstracts persisting sessions across page loads, with a default implementation based on `LocalStorage`
-- abstracts generating session IDs
-- provides a mechanism for resetting the active session after a maximum defined duration
-- provides a mechanism for resetting the active session after a defined inactivity duration
-
-Example:
+Sessions correlate multiple traces, events and logs that happen within a given time period. The
+`@opentelemetry/browser-sdk/session` subpath provides a default implementation for managing them.
 
 ```javascript
 import { startBrowserSdk } from '@opentelemetry/browser-sdk';
@@ -384,9 +376,10 @@ startBrowserSdk({
 });
 ```
 
-The session processors must be registered **before** the export processors so the `session.id` attribute is set on each span / log record before it is exported.
-
-For session lifecycle details, configuration reference, observing sessions, custom `SessionStore`/`SessionIdGenerator` implementations, and known limitations, see [Session Management](../../docs/session-management.md).
+**Session processors must be registered before the export processors.** See [Session
+Management](../../docs/session-management.md) for lifecycle details, the full configuration
+reference, observing sessions, custom `SessionStore`/`SessionIdGenerator` implementations, and
+known limitations.
 
 ## Useful links
 


### PR DESCRIPTION
## Which problem is this PR solving?

Closes #114

This PR adds dedicated documentation for browser session management to improve discoverability and provide a more comprehensive reference than the existing SDK README!

Previously, session management was only documented as a brief section inside `packages/sdk/README.md`, making it difficult for users to understand the available APIs, lifecycle, configuration options, extension points, and implementation details!

## Short description of the changes

### Added

- A new `docs/session-management.md` guide covering:
  - Session overview
  - Quick start
  - Session lifecycle
  - `SessionManager` configuration
  - Built-in implementations
  - Registering session processors
  - Observing session lifecycle
  - Custom `SessionStore` implementations
  - Custom `SessionProvider` implementations
  - Known limitations
  - Related references

### Updated

- Simplified the Sessions section in `packages/sdk/README.md` by keeping it focused on quick-start usage and linking to the new dedicated guide for detailed documentation.
- Added a new **Documentation** section to the repository `README.md` linking to:
  - Session Management
  - Browser Events
  - Navigation Event

This keeps detailed documentation centralized under the `docs/` directory while preserving a concise onboarding experience in the SDK README.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Verified all Markdown links resolve correctly
- [x] Reviewed the documentation for accuracy against the current implementation
- [x] Confirmed no runtime code or public APIs were modified
- [x] Ran the existing test suite (`npm test`) to ensure no regressions

## Checklist

- [x] I followed the style guidelines of this project
- [ ] Unit tests have been added
- [x] Documentation has been updated