### PR TITLE
feat(sandbox): add MSW mock intake panel to visualize OTLP exports

### DIFF
--- a/e2e-tests/utils/otlp-types.ts
+++ b/e2e-tests/utils/otlp-types.ts
@@ -1,0 +1,69 @@
+// otlp-types.ts — OTLP/HTTP JSON shapes shared by the e2e test collector
+// (test-collector.ts) and the sandbox mock intake (sandbox/src/mocks). Types
+// only — no runtime imports — so either workspace can consume them freely.
+
+export interface OtlpAnyValue {
+  stringValue?: string;
+  // int64 is serialized as a string in OTLP/HTTP JSON.
+  intValue?: string | number;
+  boolValue?: boolean;
+  doubleValue?: number;
+  arrayValue?: { values?: OtlpAnyValue[] };
+  kvlistValue?: { values?: OtlpKeyValue[] };
+}
+
+export interface OtlpKeyValue {
+  key: string;
+  value: OtlpAnyValue;
+}
+
+export interface OtlpScope {
+  name: string;
+  version?: string;
+}
+
+export interface OtlpResource {
+  attributes: OtlpKeyValue[];
+}
+
+export interface OtlpSpan {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  kind: number;
+  startTimeUnixNano: string;
+  endTimeUnixNano: string;
+  attributes: OtlpKeyValue[];
+  events: Array<{
+    name: string;
+    timeUnixNano: string;
+    attributes: OtlpKeyValue[];
+  }>;
+  status: { code: number; message?: string };
+}
+
+export interface OtlpLogRecord {
+  traceId?: string;
+  spanId?: string;
+  timeUnixNano?: string;
+  observedTimeUnixNano?: string;
+  severityNumber?: number;
+  severityText?: string;
+  body?: OtlpAnyValue;
+  attributes: OtlpKeyValue[];
+}
+
+export interface ExportTraceServiceRequest {
+  resourceSpans: Array<{
+    resource: OtlpResource;
+    scopeSpans: Array<{ scope: OtlpScope; spans: OtlpSpan[] }>;
+  }>;
+}
+
+export interface ExportLogsServiceRequest {
+  resourceLogs: Array<{
+    resource: OtlpResource;
+    scopeLogs: Array<{ scope: OtlpScope; logRecords: OtlpLogRecord[] }>;
+  }>;
+}

--- a/e2e-tests/utils/test-collector.ts
+++ b/e2e-tests/utils/test-collector.ts
@@ -1,68 +1,19 @@
 import type { HttpHandler } from 'msw';
 import { HttpResponse, http } from 'msw';
 import { setupWorker } from 'msw/browser';
+import type {
+  ExportLogsServiceRequest,
+  ExportTraceServiceRequest,
+  OtlpLogRecord,
+  OtlpSpan,
+} from './otlp-types.ts';
+
+// Re-exported for backwards compatibility; the shapes now live in otlp-types.ts
+// and are shared with the sandbox mock intake.
+export type { OtlpKeyValue, OtlpLogRecord, OtlpSpan } from './otlp-types.ts';
 
 export const COLLECTOR_URL = 'http://localhost:4318/v1/traces';
 export const LOGS_COLLECTOR_URL = 'http://localhost:4318/v1/logs';
-
-// ── OTLP JSON types ────────────────────────────────────────────────────────────
-
-interface OtlpAnyValue {
-  stringValue?: string;
-  intValue?: number;
-  boolValue?: boolean;
-  doubleValue?: number;
-}
-
-export interface OtlpKeyValue {
-  key: string;
-  value: OtlpAnyValue;
-}
-
-export interface OtlpSpan {
-  traceId: string;
-  spanId: string;
-  parentSpanId?: string;
-  name: string;
-  kind: number;
-  startTimeUnixNano: string;
-  endTimeUnixNano: string;
-  attributes: OtlpKeyValue[];
-  events: Array<{
-    name: string;
-    timeUnixNano: string;
-    attributes: OtlpKeyValue[];
-  }>;
-  status: { code: number; message?: string };
-}
-
-export interface OtlpLogRecord {
-  traceId?: string;
-  spanId?: string;
-  severityNumber?: number;
-  severityText?: string;
-  attributes: OtlpKeyValue[];
-}
-
-interface ExportTraceServiceRequest {
-  resourceSpans: Array<{
-    resource: { attributes: OtlpKeyValue[] };
-    scopeSpans: Array<{
-      scope: { name: string; version?: string };
-      spans: OtlpSpan[];
-    }>;
-  }>;
-}
-
-interface ExportLogsServiceRequest {
-  resourceLogs: Array<{
-    resource: { attributes: OtlpKeyValue[] };
-    scopeLogs: Array<{
-      scope: { name: string; version?: string };
-      logRecords: OtlpLogRecord[];
-    }>;
-  }>;
-}
 
 // ── Internal singleton state ───────────────────────────────────────────────────
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4946,9 +4946,9 @@
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.15.0.tgz",
-      "integrity": "sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ==",
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.6.tgz",
+      "integrity": "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -6661,7 +6661,7 @@
       "devDependencies": {
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
-        "msw": "^2.15.0"
+        "msw": "^2.14.6"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4946,9 +4946,9 @@
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "2.14.6",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.6.tgz",
-      "integrity": "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.15.0.tgz",
+      "integrity": "sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -6660,7 +6660,8 @@
       },
       "devDependencies": {
         "@types/react": "19.2.17",
-        "@types/react-dom": "19.2.3"
+        "@types/react-dom": "19.2.3",
+        "msw": "^2.15.0"
       }
     }
   }

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
-    "msw": "^2.15.0"
+    "msw": "^2.14.6"
   },
   "msw": {
     "workerDirectory": [

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -25,6 +25,12 @@
   },
   "devDependencies": {
     "@types/react": "19.2.17",
-    "@types/react-dom": "19.2.3"
+    "@types/react-dom": "19.2.3",
+    "msw": "^2.15.0"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/sandbox/public/mockServiceWorker.js
+++ b/sandbox/public/mockServiceWorker.js
@@ -7,8 +7,8 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.15.0'
-const INTEGRITY_CHECKSUM = '03cb67ac84128e63d7cd722a6e5b7f1e'
+const PACKAGE_VERSION = '2.14.6'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
@@ -137,18 +137,8 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
   if (client && activeClientIds.has(client.id)) {
     const serializedRequest = await serializeRequest(requestCloneForEvents)
 
-    // Omit the body of server-sent event stream responses.
-    // Cloning such responses would prevent client-side stream cancelations
-    // from reaching the original stream (a teed stream only cancels its
-    // source once both of its branches cancel) and would buffer the
-    // entire stream into the unconsumed clone indefinitely.
-    const isEventStreamResponse = response.headers
-      .get('content-type')
-      ?.toLowerCase()
-      .startsWith('text/event-stream')
-
     // Clone the response so both the client and the library could consume it.
-    const responseClone = isEventStreamResponse ? null : response.clone()
+    const responseClone = response.clone()
 
     sendToClient(
       client,
@@ -161,17 +151,15 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
             ...serializedRequest,
           },
           response: {
-            type: response.type,
-            status: response.status,
-            statusText: response.statusText,
-            headers: Object.fromEntries(response.headers.entries()),
-            body: responseClone ? responseClone.body : null,
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
           },
         },
       },
-      responseClone && responseClone.body
-        ? [serializedRequest.body, responseClone.body]
-        : [],
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
     )
   }
 

--- a/sandbox/public/mockServiceWorker.js
+++ b/sandbox/public/mockServiceWorker.js
@@ -1,0 +1,361 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.15.0'
+const INTEGRITY_CHECKSUM = '03cb67ac84128e63d7cd722a6e5b7f1e'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Omit the body of server-sent event stream responses.
+    // Cloning such responses would prevent client-side stream cancelations
+    // from reaching the original stream (a teed stream only cancels its
+    // source once both of its branches cancel) and would buffer the
+    // entire stream into the unconsumed clone indefinitely.
+    const isEventStreamResponse = response.headers
+      .get('content-type')
+      ?.toLowerCase()
+      .startsWith('text/event-stream')
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = isEventStreamResponse ? null : response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: response.type,
+            status: response.status,
+            statusText: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body: responseClone ? responseClone.body : null,
+          },
+        },
+      },
+      responseClone && responseClone.body
+        ? [serializedRequest.body, responseClone.body]
+        : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/sandbox/src/app/App.tsx
+++ b/sandbox/src/app/App.tsx
@@ -6,10 +6,11 @@ import { ActionsPanel } from './components/ActionsPanel.tsx';
 import { CodeSnippet } from './components/CodeSnippet.tsx';
 import type { LogEntry } from './components/EventLog.tsx';
 import { EventLog } from './components/EventLog.tsx';
+import { IntakePanel } from './components/IntakePanel.tsx';
 import { SandboxConfigForm } from './components/SandboxConfigForm.tsx';
 import { useSandboxConfig } from './hooks/use-sandbox-config.ts';
 
-export function App() {
+export function App({ intakeMock = false }: { intakeMock?: boolean }) {
   const cfg = useSandboxConfig();
 
   // ── SDK state ─────────────────────────────────────────────────────────────
@@ -124,12 +125,15 @@ export function App() {
           <ActionsPanel ready={ready} act={act} sessionId={sessionId} />
         </div>
 
-        <article>
-          <header>
-            <strong>Equivalent SDK init</strong>
-          </header>
-          <CodeSnippet config={cfg.config} attrs={cfg.attrs} />
-        </article>
+        <div className="right-col">
+          <article>
+            <header>
+              <strong>Equivalent SDK init</strong>
+            </header>
+            <CodeSnippet config={cfg.config} attrs={cfg.attrs} />
+          </article>
+          {intakeMock && <IntakePanel />}
+        </div>
       </div>
 
       <EventLog logs={logs} onClear={() => setLogs([])} />

--- a/sandbox/src/app/components/IntakePanel.tsx
+++ b/sandbox/src/app/components/IntakePanel.tsx
@@ -3,7 +3,9 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import type { IntakeRecord, IntakeRequest } from '../../mocks/intake-bus.ts';
-import { onIntake } from '../../mocks/intake-bus.ts';
+import { onIntake, toCollectorDebug } from '../../mocks/intake-bus.ts';
+
+type RequestView = 'none' | 'collector' | 'raw';
 
 const MAX_REQUESTS = 50;
 
@@ -53,8 +55,9 @@ function RecordRow({ record }: { record: IntakeRecord }) {
 }
 
 function RequestCard({ req }: { req: IntakeRequest }) {
-  const [showRaw, setShowRaw] = useState(false);
+  const [view, setView] = useState<RequestView>('none');
   const scopes = useMemo(() => byScope(req.records), [req.records]);
+  const toggle = (v: RequestView) => setView((cur) => (cur === v ? 'none' : v));
   const path = (() => {
     try {
       return new URL(req.url).pathname;
@@ -92,14 +95,26 @@ function RequestCard({ req }: { req: IntakeRequest }) {
         </div>
       ))}
 
-      <button
-        type="button"
-        className="intake-raw-toggle"
-        onClick={() => setShowRaw((s) => !s)}
-      >
-        {showRaw ? 'hide raw OTLP JSON' : 'raw OTLP JSON'}
-      </button>
-      {showRaw && (
+      <div className="intake-views">
+        <button
+          type="button"
+          className={`intake-raw-toggle ${view === 'collector' ? 'active' : ''}`}
+          onClick={() => toggle('collector')}
+        >
+          collector debug view
+        </button>
+        <button
+          type="button"
+          className={`intake-raw-toggle ${view === 'raw' ? 'active' : ''}`}
+          onClick={() => toggle('raw')}
+        >
+          raw OTLP JSON
+        </button>
+      </div>
+      {view === 'collector' && (
+        <pre className="intake-raw">{toCollectorDebug(req)}</pre>
+      )}
+      {view === 'raw' && (
         <pre className="intake-raw">{JSON.stringify(req.raw, null, 2)}</pre>
       )}
     </details>

--- a/sandbox/src/app/components/IntakePanel.tsx
+++ b/sandbox/src/app/components/IntakePanel.tsx
@@ -1,0 +1,156 @@
+// IntakePanel.tsx — "what the collector received", decoded from the OTLP/HTTP
+// payloads intercepted by the mock intake (see src/mocks/).
+
+import { useEffect, useMemo, useState } from 'react';
+import type { IntakeRecord, IntakeRequest } from '../../mocks/intake-bus.ts';
+import { onIntake } from '../../mocks/intake-bus.ts';
+
+const MAX_REQUESTS = 50;
+
+function shortId(id?: string, n = 8): string {
+  return id ? `${id.slice(0, n)}…` : '—';
+}
+
+function timeOf(at: number): string {
+  return new Date(at).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function fmtBytes(bytes: number): string {
+  return bytes < 1024 ? `${bytes} B` : `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+// Group records under their instrumentation scope for display.
+function byScope(records: IntakeRecord[]): [string, IntakeRecord[]][] {
+  const map = new Map<string, IntakeRecord[]>();
+  for (const r of records) {
+    const list = map.get(r.scope) ?? [];
+    list.push(r);
+    map.set(r.scope, list);
+  }
+  return [...map.entries()];
+}
+
+function RecordRow({ record }: { record: IntakeRecord }) {
+  const icon =
+    record.kind === 'log' ? '◆' : record.status === 'error' ? '✗' : '●';
+  return (
+    <div className={`intake-record ${record.status}`}>
+      <span className="intake-icon">{icon}</span>
+      <span className="intake-name">{record.name}</span>
+      <span className="intake-detail">{record.detail}</span>
+      {record.traceId && (
+        <span className="intake-tag">trace={shortId(record.traceId)}</span>
+      )}
+      {record.sessionId && (
+        <span className="intake-chip">session={shortId(record.sessionId)}</span>
+      )}
+    </div>
+  );
+}
+
+function RequestCard({ req }: { req: IntakeRequest }) {
+  const [showRaw, setShowRaw] = useState(false);
+  const scopes = useMemo(() => byScope(req.records), [req.records]);
+  const path = (() => {
+    try {
+      return new URL(req.url).pathname;
+    } catch {
+      return req.url;
+    }
+  })();
+
+  return (
+    <details className="intake-req">
+      <summary>
+        <span className="intake-time">{timeOf(req.at)}</span>
+        <span className={`intake-badge ${req.signal}`}>{req.signal}</span>
+        <span className="intake-summary-text">
+          POST {path} · {req.records.length}{' '}
+          {req.signal === 'traces' ? 'span' : 'log'}
+          {req.records.length === 1 ? '' : 's'} · {fmtBytes(req.bytes)}
+        </span>
+      </summary>
+
+      <div className="intake-resource">
+        {Object.entries(req.resource).map(([k, v]) => (
+          <span className="intake-tag" key={k}>
+            {k}={String(v)}
+          </span>
+        ))}
+      </div>
+
+      {scopes.map(([scope, records]) => (
+        <div className="intake-scope" key={scope}>
+          <div className="intake-scope-name">— {scope} —</div>
+          {records.map((r) => (
+            <RecordRow key={`${r.spanId ?? r.name}-${r.detail}`} record={r} />
+          ))}
+        </div>
+      ))}
+
+      <button
+        type="button"
+        className="intake-raw-toggle"
+        onClick={() => setShowRaw((s) => !s)}
+      >
+        {showRaw ? 'hide raw OTLP JSON' : 'raw OTLP JSON'}
+      </button>
+      {showRaw && (
+        <pre className="intake-raw">{JSON.stringify(req.raw, null, 2)}</pre>
+      )}
+    </details>
+  );
+}
+
+export function IntakePanel() {
+  const [requests, setRequests] = useState<IntakeRequest[]>([]);
+
+  useEffect(
+    () =>
+      onIntake((req) =>
+        setRequests((prev) => [req, ...prev].slice(0, MAX_REQUESTS)),
+      ),
+    [],
+  );
+
+  const activeSession = requests
+    .flatMap((r) => r.records)
+    .find((r) => r.sessionId)?.sessionId;
+
+  return (
+    <article>
+      <header>
+        <strong>
+          Intake received <small>({requests.length})</small>
+        </strong>
+        {activeSession && (
+          <span className="intake-chip" style={{ marginLeft: '0.5rem' }}>
+            session={shortId(activeSession)}
+          </span>
+        )}
+        <button
+          type="button"
+          className="outline"
+          style={{ marginLeft: '0.5rem' }}
+          onClick={() => setRequests([])}
+        >
+          Clear
+        </button>
+      </header>
+      <div className="intake-body">
+        {requests.length === 0 ? (
+          <p className="intake-empty">
+            Waiting for OTLP exports… trigger an action to see what the
+            collector would receive over the wire.
+          </p>
+        ) : (
+          requests.map((req) => <RequestCard key={req.id} req={req} />)
+        )}
+      </div>
+    </article>
+  );
+}

--- a/sandbox/src/app/style.css
+++ b/sandbox/src/app/style.css
@@ -336,8 +336,14 @@ input {
   padding: 0.02rem 0.3rem;
 }
 
+.intake-views {
+  display: flex;
+  gap: 0.4rem;
+  padding-left: 0.75rem;
+  margin: 0.35rem 0;
+}
+
 .intake-raw-toggle {
-  margin: 0.35rem 0 0.35rem 0.75rem;
   padding: 0.1rem 0.4rem;
   font-size: 0.68rem;
   width: auto;
@@ -345,6 +351,11 @@ input {
   border: 1px solid var(--pico-muted-border-color);
   color: var(--pico-muted-color);
   border-radius: 0.25rem;
+}
+
+.intake-raw-toggle.active {
+  border-color: var(--pico-primary);
+  color: var(--pico-primary);
 }
 
 .intake-raw {

--- a/sandbox/src/app/style.css
+++ b/sandbox/src/app/style.css
@@ -31,7 +31,8 @@ input {
   }
 }
 
-.left-col {
+.left-col,
+.right-col {
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -224,4 +225,131 @@ input {
 }
 .log-msg-muted {
   color: var(--pico-muted-color);
+}
+
+/* ── Intake panel ─────────────────────────────────────────────────────────────── */
+
+.intake-body {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.intake-empty {
+  color: var(--pico-muted-color);
+  font-size: 0.8rem;
+}
+
+.intake-req {
+  border-bottom: 1px solid var(--pico-muted-border-color);
+  padding: 0.15rem 0;
+}
+
+.intake-req > summary {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.2rem 0;
+}
+
+.intake-time {
+  color: var(--pico-muted-color);
+  font-size: 0.7rem;
+}
+
+.intake-badge {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  border-radius: 0.25rem;
+  padding: 0.05rem 0.35rem;
+  color: #fff;
+}
+.intake-badge.traces {
+  background: #7c3aed;
+}
+.intake-badge.logs {
+  background: #0891b2;
+}
+
+.intake-summary-text {
+  color: var(--pico-color);
+}
+
+.intake-resource {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  padding: 0.35rem 0 0.35rem 1rem;
+}
+
+.intake-scope {
+  padding-left: 1rem;
+}
+
+.intake-scope-name {
+  color: var(--pico-muted-color);
+  font-size: 0.7rem;
+  margin: 0.2rem 0;
+}
+
+.intake-record {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding: 0.1rem 0 0.1rem 0.75rem;
+  line-height: 1.5;
+}
+
+.intake-icon {
+  color: #7c3aed;
+}
+
+.intake-name {
+  font-weight: 600;
+}
+
+.intake-detail {
+  color: var(--pico-muted-color);
+}
+
+.intake-record.error .intake-icon,
+.intake-record.error .intake-name {
+  color: red;
+}
+
+.intake-tag {
+  font-size: 0.68rem;
+  color: var(--pico-muted-color);
+  background: var(--pico-code-background-color, #2a2a3a);
+  border-radius: 0.25rem;
+  padding: 0.02rem 0.3rem;
+}
+
+.intake-chip {
+  font-size: 0.68rem;
+  color: #a6e3a1;
+  background: rgba(166, 227, 161, 0.12);
+  border-radius: 0.25rem;
+  padding: 0.02rem 0.3rem;
+}
+
+.intake-raw-toggle {
+  margin: 0.35rem 0 0.35rem 0.75rem;
+  padding: 0.1rem 0.4rem;
+  font-size: 0.68rem;
+  width: auto;
+  background: transparent;
+  border: 1px solid var(--pico-muted-border-color);
+  color: var(--pico-muted-color);
+  border-radius: 0.25rem;
+}
+
+.intake-raw {
+  font-size: 0.68rem;
+  max-height: 220px;
+  overflow: auto;
+  margin: 0 0 0.5rem 0.75rem;
 }

--- a/sandbox/src/main.tsx
+++ b/sandbox/src/main.tsx
@@ -2,8 +2,32 @@ import './app/style.css';
 import { createRoot } from 'react-dom/client';
 import { App } from './app/App.tsx';
 
+// Start the mock OTLP intake before rendering so the MSW worker is intercepting
+// before the SDK fires its first export. Enabled in dev by default, and on any
+// build via `?intake=mock` (handy for the deployed GitHub Pages showcase).
+async function enableIntakeMock(): Promise<boolean> {
+  const forced =
+    new URLSearchParams(window.location.search).get('intake') === 'mock';
+  if (!import.meta.env.DEV && !forced) {
+    return false;
+  }
+  const { worker } = await import('./mocks/browser.ts');
+  await worker.start({
+    onUnhandledRequest: 'bypass',
+    quiet: true,
+    // Respect the /opentelemetry-browser/ base path on GitHub Pages.
+    serviceWorker: { url: `${import.meta.env.BASE_URL}mockServiceWorker.js` },
+  });
+  return true;
+}
+
 const rootElement = document.getElementById('root');
 if (!rootElement) {
   throw new Error('Root element not found');
 }
-createRoot(rootElement).render(<App />);
+
+enableIntakeMock()
+  .catch(() => false)
+  .then((intakeMock) => {
+    createRoot(rootElement).render(<App intakeMock={intakeMock} />);
+  });

--- a/sandbox/src/main.tsx
+++ b/sandbox/src/main.tsx
@@ -3,12 +3,16 @@ import { createRoot } from 'react-dom/client';
 import { App } from './app/App.tsx';
 
 // Start the mock OTLP intake before rendering so the MSW worker is intercepting
-// before the SDK fires its first export. Enabled in dev by default, and on any
-// build via `?intake=mock` (handy for the deployed GitHub Pages showcase).
+// before the SDK fires its first export. Enabled by default (in dev and on the
+// deployed GitHub Pages showcase); opt out with `?intake=off`.
 async function enableIntakeMock(): Promise<boolean> {
-  const forced =
-    new URLSearchParams(window.location.search).get('intake') === 'mock';
-  if (!import.meta.env.DEV && !forced) {
+  const disabled =
+    new URLSearchParams(window.location.search).get('intake') === 'off';
+  if (disabled) {
+    // Opted out via `?intake=off`: tear down any MSW worker left registered by
+    // a previous visit so it can't keep controlling the page and silently
+    // intercepting real OTLP exports.
+    await unregisterIntakeWorker();
     return false;
   }
   const { worker } = await import('./mocks/browser.ts');
@@ -19,6 +23,19 @@ async function enableIntakeMock(): Promise<boolean> {
     serviceWorker: { url: `${import.meta.env.BASE_URL}mockServiceWorker.js` },
   });
   return true;
+}
+
+// Unregister any service worker previously installed by the mock intake.
+async function unregisterIntakeWorker(): Promise<void> {
+  if (!('serviceWorker' in navigator)) {
+    return;
+  }
+  const registrations = await navigator.serviceWorker.getRegistrations();
+  await Promise.all(
+    registrations
+      .filter((r) => r.active?.scriptURL.includes('mockServiceWorker'))
+      .map((r) => r.unregister()),
+  );
 }
 
 const rootElement = document.getElementById('root');

--- a/sandbox/src/mocks/browser.ts
+++ b/sandbox/src/mocks/browser.ts
@@ -1,0 +1,9 @@
+// browser.ts — the MSW worker for the mock OTLP intake.
+//
+// This module (and `msw` itself) is only ever pulled in via the dynamic import
+// in main.tsx, so it stays out of the main bundle when the mock is disabled.
+
+import { setupWorker } from 'msw/browser';
+import { handlers } from './handlers.ts';
+
+export const worker = setupWorker(...handlers);

--- a/sandbox/src/mocks/handlers.ts
+++ b/sandbox/src/mocks/handlers.ts
@@ -1,0 +1,21 @@
+// handlers.ts — MSW handlers that intercept the SDK's OTLP/HTTP exports.
+//
+// The wildcard host (`*`) matches whatever endpoint the sandbox is configured
+// with (localhost:4318 by default, or a custom URL from the config form), while
+// still being cross-origin-safe: MSW answers the request inside the browser, so
+// there is no real network call and therefore no CORS preflight.
+
+import { HttpResponse, http } from 'msw';
+import { ingest } from './intake-bus.ts';
+
+export const handlers = [
+  http.post('*/v1/traces', async ({ request }) => {
+    ingest('traces', request.url, await request.text());
+    // OTLP success response is an empty JSON body with a 200 status.
+    return HttpResponse.json({}, { status: 200 });
+  }),
+  http.post('*/v1/logs', async ({ request }) => {
+    ingest('logs', request.url, await request.text());
+    return HttpResponse.json({}, { status: 200 });
+  }),
+];

--- a/sandbox/src/mocks/intake-bus.ts
+++ b/sandbox/src/mocks/intake-bus.ts
@@ -135,6 +135,142 @@ function decodeLogs(body: Json): Pick<IntakeRequest, 'resource' | 'records'> {
   return { resource, records };
 }
 
+// ── Collector debug-exporter formatting ───────────────────────────────────────
+// Mimics the text the OpenTelemetry Collector's `debug` exporter prints
+// (verbosity: detailed), so the panel can show "what the collector would log".
+// This is a faithful format-only simulation — no real collector is involved.
+
+const SPAN_KINDS = [
+  'Unspecified',
+  'Internal',
+  'Server',
+  'Client',
+  'Producer',
+  'Consumer',
+];
+const STATUS_CODES = ['Unset', 'Ok', 'Error'];
+
+// Render an OTLP AnyValue with the collector's `Type(value)` notation.
+function otlpValue(v: Json): string {
+  if (v == null) {
+    return 'Empty()';
+  }
+  if ('stringValue' in v) {
+    return `Str(${v.stringValue})`;
+  }
+  if ('boolValue' in v) {
+    return `Bool(${v.boolValue})`;
+  }
+  if ('intValue' in v) {
+    return `Int(${v.intValue})`;
+  }
+  if ('doubleValue' in v) {
+    return `Double(${v.doubleValue})`;
+  }
+  if ('arrayValue' in v) {
+    const items = (v.arrayValue?.values ?? []).map(otlpValue).join(', ');
+    return `Slice([${items}])`;
+  }
+  if ('kvlistValue' in v) {
+    const items = (v.kvlistValue?.values ?? [])
+      .map((kv: Json) => `${kv.key}:${otlpValue(kv.value)}`)
+      .join(', ');
+    return `Map(${items})`;
+  }
+  return 'Empty()';
+}
+
+function resourceLines(attrs: Json[] = []): string {
+  const lines = attrs.map((a) => `     -> ${a.key}: ${otlpValue(a.value)}`);
+  return `Resource attributes:\n${lines.join('\n')}\n`;
+}
+
+function attrLines(attrs: Json[] = [], indent: string): string {
+  if (!attrs.length) {
+    return '';
+  }
+  const lines = attrs.map(
+    (a) => `${indent}     -> ${a.key}: ${otlpValue(a.value)}`,
+  );
+  return `${indent}Attributes:\n${lines.join('\n')}\n`;
+}
+
+function ts(nano?: string): string {
+  if (!nano) {
+    return '';
+  }
+  return new Date(Number(nano) / 1_000_000).toISOString();
+}
+
+function severityLabel(n?: number): string {
+  if (!n) {
+    return 'Unspecified(0)';
+  }
+  const names = ['', 'Trace', 'Debug', 'Info', 'Warn', 'Error', 'Fatal'];
+  return `${names[Math.min(6, Math.ceil(n / 4))] || 'Unspecified'}(${n})`;
+}
+
+function debugTraces(body: Json): string {
+  const out: string[] = [];
+  (body.resourceSpans ?? []).forEach((rs: Json, i: number) => {
+    out.push(`ResourceSpans #${i}`, resourceLines(rs.resource?.attributes));
+    (rs.scopeSpans ?? []).forEach((ss: Json, j: number) => {
+      out.push(
+        `ScopeSpans #${j}`,
+        `InstrumentationScope ${ss.scope?.name ?? ''} ${ss.scope?.version ?? ''}`,
+      );
+      (ss.spans ?? []).forEach((span: Json, k: number) => {
+        out.push(
+          `Span #${k}`,
+          `    Trace ID       : ${span.traceId ?? ''}`,
+          `    Parent ID      : ${span.parentSpanId ?? ''}`,
+          `    ID             : ${span.spanId ?? ''}`,
+          `    Name           : ${span.name ?? ''}`,
+          `    Kind           : ${SPAN_KINDS[span.kind ?? 0] ?? 'Unspecified'}`,
+          `    Start time     : ${ts(span.startTimeUnixNano)}`,
+          `    End time       : ${ts(span.endTimeUnixNano)}`,
+          `    Status code    : ${STATUS_CODES[span.status?.code ?? 0] ?? 'Unset'}`,
+          attrLines(span.attributes, '    ').trimEnd(),
+        );
+      });
+    });
+  });
+  return out.join('\n');
+}
+
+function debugLogs(body: Json): string {
+  const out: string[] = [];
+  (body.resourceLogs ?? []).forEach((rl: Json, i: number) => {
+    out.push(`ResourceLog #${i}`, resourceLines(rl.resource?.attributes));
+    (rl.scopeLogs ?? []).forEach((sl: Json, j: number) => {
+      out.push(
+        `ScopeLogs #${j}`,
+        `InstrumentationScope ${sl.scope?.name ?? ''} ${sl.scope?.version ?? ''}`,
+      );
+      (sl.logRecords ?? []).forEach((log: Json, k: number) => {
+        out.push(
+          `LogRecord #${k}`,
+          `    ObservedTimestamp : ${ts(log.observedTimeUnixNano)}`,
+          `    Timestamp         : ${ts(log.timeUnixNano)}`,
+          `    SeverityText      : ${log.severityText ?? ''}`,
+          `    SeverityNumber    : ${severityLabel(log.severityNumber)}`,
+          `    Body              : ${otlpValue(log.body)}`,
+          attrLines(log.attributes, '    ').trimEnd(),
+          `    Trace ID          : ${log.traceId ?? ''}`,
+          `    Span ID           : ${log.spanId ?? ''}`,
+        );
+      });
+    });
+  });
+  return out.join('\n');
+}
+
+/** Format an intercepted request the way the collector's `debug` exporter would. */
+export function toCollectorDebug(req: IntakeRequest): string {
+  const body = req.raw as Json;
+  return req.signal === 'traces' ? debugTraces(body) : debugLogs(body);
+}
+
 // ── Pub/sub ───────────────────────────────────────────────────────────────────
 
 const bus = new EventTarget();

--- a/sandbox/src/mocks/intake-bus.ts
+++ b/sandbox/src/mocks/intake-bus.ts
@@ -1,0 +1,182 @@
+// intake-bus.ts — decode intercepted OTLP/HTTP JSON and fan it out to the UI.
+//
+// This module is intentionally free of any `msw` import so it can be pulled
+// into the main app bundle (the MSW worker + handlers are code-split and only
+// loaded when the mock intake is enabled — see mocks/browser.ts).
+
+export type Signal = 'traces' | 'logs';
+
+export interface IntakeRecord {
+  kind: 'span' | 'log';
+  /** Instrumentation scope that produced the record, e.g. "…/instrumentation-fetch". */
+  scope: string;
+  /** Span name, or the log severity for log records. */
+  name: string;
+  /** Short human detail: span duration ("156.0ms") or the log body. */
+  detail: string;
+  traceId?: string;
+  spanId?: string;
+  sessionId?: string;
+  status: 'ok' | 'error' | 'unset';
+  attributes: Record<string, unknown>;
+}
+
+export interface IntakeRequest {
+  id: number;
+  signal: Signal;
+  /** Full URL the SDK POSTed to (e.g. http://localhost:4318/v1/traces). */
+  url: string;
+  /** Epoch millis the request was intercepted. */
+  at: number;
+  /** Byte size of the JSON payload on the wire. */
+  bytes: number;
+  /** Resource attributes shared by every record in the request. */
+  resource: Record<string, unknown>;
+  records: IntakeRecord[];
+  /** The raw OTLP JSON, kept for the "raw" toggle. */
+  raw: unknown;
+}
+
+// ── OTLP AnyValue / KeyValue decoding ─────────────────────────────────────────
+
+// biome-ignore lint/suspicious/noExplicitAny: OTLP JSON is dynamically shaped.
+type Json = any;
+
+function anyValue(v: Json): unknown {
+  if (v == null) {
+    return undefined;
+  }
+  if ('stringValue' in v) {
+    return v.stringValue;
+  }
+  if ('boolValue' in v) {
+    return v.boolValue;
+  }
+  if ('intValue' in v) {
+    return Number(v.intValue);
+  }
+  if ('doubleValue' in v) {
+    return v.doubleValue;
+  }
+  if ('arrayValue' in v) {
+    return (v.arrayValue?.values ?? []).map(anyValue);
+  }
+  if ('kvlistValue' in v) {
+    return keyValues(v.kvlistValue?.values);
+  }
+  return undefined;
+}
+
+function keyValues(kvs: Json[] = []): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const kv of kvs) {
+    out[kv.key] = anyValue(kv.value);
+  }
+  return out;
+}
+
+function durationMs(span: Json): string {
+  // start/end are int64 nanoseconds serialized as strings in OTLP JSON.
+  const ns = Number(span.endTimeUnixNano) - Number(span.startTimeUnixNano);
+  return `${(ns / 1_000_000).toFixed(1)}ms`;
+}
+
+function decodeTraces(body: Json): Pick<IntakeRequest, 'resource' | 'records'> {
+  const records: IntakeRecord[] = [];
+  let resource: Record<string, unknown> = {};
+  for (const rs of body.resourceSpans ?? []) {
+    resource = keyValues(rs.resource?.attributes);
+    for (const ss of rs.scopeSpans ?? []) {
+      const scope = ss.scope?.name || 'unknown';
+      for (const span of ss.spans ?? []) {
+        const attributes = keyValues(span.attributes);
+        const code = span.status?.code;
+        records.push({
+          kind: 'span',
+          scope,
+          name: span.name,
+          detail: durationMs(span),
+          traceId: span.traceId,
+          spanId: span.spanId,
+          sessionId: attributes['session.id'] as string | undefined,
+          status: code === 2 ? 'error' : code === 1 ? 'ok' : 'unset',
+          attributes,
+        });
+      }
+    }
+  }
+  return { resource, records };
+}
+
+function decodeLogs(body: Json): Pick<IntakeRequest, 'resource' | 'records'> {
+  const records: IntakeRecord[] = [];
+  let resource: Record<string, unknown> = {};
+  for (const rl of body.resourceLogs ?? []) {
+    resource = keyValues(rl.resource?.attributes);
+    for (const sl of rl.scopeLogs ?? []) {
+      const scope = sl.scope?.name || 'unknown';
+      for (const log of sl.logRecords ?? []) {
+        const attributes = keyValues(log.attributes);
+        const body = anyValue(log.body);
+        records.push({
+          kind: 'log',
+          scope,
+          name: log.severityText || 'LOG',
+          detail: typeof body === 'string' ? body : JSON.stringify(body),
+          traceId: log.traceId,
+          spanId: log.spanId,
+          sessionId: attributes['session.id'] as string | undefined,
+          status: 'unset',
+          attributes,
+        });
+      }
+    }
+  }
+  return { resource, records };
+}
+
+// ── Pub/sub ───────────────────────────────────────────────────────────────────
+
+const bus = new EventTarget();
+let seq = 0;
+
+export function onIntake(cb: (req: IntakeRequest) => void): () => void {
+  const handler = (e: Event) => cb((e as CustomEvent<IntakeRequest>).detail);
+  bus.addEventListener('intake', handler);
+  return () => bus.removeEventListener('intake', handler);
+}
+
+/**
+ * Parse an intercepted OTLP/HTTP JSON body and publish it to subscribers.
+ * Called by the MSW request handlers.
+ */
+export function ingest(signal: Signal, url: string, text: string): void {
+  let body: Json;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    return;
+  }
+  const bytes = new TextEncoder().encode(text).length;
+  const { resource, records } =
+    signal === 'traces' ? decodeTraces(body) : decodeLogs(body);
+
+  const req: IntakeRequest = {
+    id: ++seq,
+    signal,
+    url,
+    at: Date.now(),
+    bytes,
+    resource,
+    records,
+    raw: body,
+  };
+
+  if (import.meta.env.DEV) {
+    console.debug(
+      `[intake] ${signal} · ${records.length} record(s) · ${bytes}B`,
+      body,
+    );
+  }
+  bus.dispatchEvent(new CustomEvent('intake', { detail: req }));
+}

--- a/sandbox/src/mocks/intake-bus.ts
+++ b/sandbox/src/mocks/intake-bus.ts
@@ -4,6 +4,16 @@
 // into the main app bundle (the MSW worker + handlers are code-split and only
 // loaded when the mock intake is enabled — see mocks/browser.ts).
 
+// OTLP/HTTP JSON shapes are shared with the e2e test collector (type-only
+// import — nothing from that workspace ends up in the sandbox bundle).
+import type {
+  ExportLogsServiceRequest,
+  ExportTraceServiceRequest,
+  OtlpAnyValue,
+  OtlpKeyValue,
+  OtlpSpan,
+} from '../../../e2e-tests/utils/otlp-types.ts';
+
 export type Signal = 'traces' | 'logs';
 
 export interface IntakeRecord {
@@ -39,10 +49,7 @@ export interface IntakeRequest {
 
 // ── OTLP AnyValue / KeyValue decoding ─────────────────────────────────────────
 
-// biome-ignore lint/suspicious/noExplicitAny: OTLP JSON is dynamically shaped.
-type Json = any;
-
-function anyValue(v: Json): unknown {
+function anyValue(v: OtlpAnyValue | undefined): unknown {
   if (v == null) {
     return undefined;
   }
@@ -67,7 +74,7 @@ function anyValue(v: Json): unknown {
   return undefined;
 }
 
-function keyValues(kvs: Json[] = []): Record<string, unknown> {
+function keyValues(kvs: OtlpKeyValue[] = []): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const kv of kvs) {
     out[kv.key] = anyValue(kv.value);
@@ -75,13 +82,15 @@ function keyValues(kvs: Json[] = []): Record<string, unknown> {
   return out;
 }
 
-function durationMs(span: Json): string {
+function durationMs(span: OtlpSpan): string {
   // start/end are int64 nanoseconds serialized as strings in OTLP JSON.
   const ns = Number(span.endTimeUnixNano) - Number(span.startTimeUnixNano);
   return `${(ns / 1_000_000).toFixed(1)}ms`;
 }
 
-function decodeTraces(body: Json): Pick<IntakeRequest, 'resource' | 'records'> {
+function decodeTraces(
+  body: ExportTraceServiceRequest,
+): Pick<IntakeRequest, 'resource' | 'records'> {
   const records: IntakeRecord[] = [];
   let resource: Record<string, unknown> = {};
   for (const rs of body.resourceSpans ?? []) {
@@ -94,7 +103,7 @@ function decodeTraces(body: Json): Pick<IntakeRequest, 'resource' | 'records'> {
         records.push({
           kind: 'span',
           scope,
-          name: span.name,
+          name: span.name ?? '',
           detail: durationMs(span),
           traceId: span.traceId,
           spanId: span.spanId,
@@ -108,7 +117,9 @@ function decodeTraces(body: Json): Pick<IntakeRequest, 'resource' | 'records'> {
   return { resource, records };
 }
 
-function decodeLogs(body: Json): Pick<IntakeRequest, 'resource' | 'records'> {
+function decodeLogs(
+  body: ExportLogsServiceRequest,
+): Pick<IntakeRequest, 'resource' | 'records'> {
   const records: IntakeRecord[] = [];
   let resource: Record<string, unknown> = {};
   for (const rl of body.resourceLogs ?? []) {
@@ -117,12 +128,13 @@ function decodeLogs(body: Json): Pick<IntakeRequest, 'resource' | 'records'> {
       const scope = sl.scope?.name || 'unknown';
       for (const log of sl.logRecords ?? []) {
         const attributes = keyValues(log.attributes);
-        const body = anyValue(log.body);
+        const logBody = anyValue(log.body);
         records.push({
           kind: 'log',
           scope,
           name: log.severityText || 'LOG',
-          detail: typeof body === 'string' ? body : JSON.stringify(body),
+          detail:
+            typeof logBody === 'string' ? logBody : JSON.stringify(logBody),
           traceId: log.traceId,
           spanId: log.spanId,
           sessionId: attributes['session.id'] as string | undefined,
@@ -151,7 +163,7 @@ const SPAN_KINDS = [
 const STATUS_CODES = ['Unset', 'Ok', 'Error'];
 
 // Render an OTLP AnyValue with the collector's `Type(value)` notation.
-function otlpValue(v: Json): string {
+function otlpValue(v: OtlpAnyValue | undefined): string {
   if (v == null) {
     return 'Empty()';
   }
@@ -173,19 +185,19 @@ function otlpValue(v: Json): string {
   }
   if ('kvlistValue' in v) {
     const items = (v.kvlistValue?.values ?? [])
-      .map((kv: Json) => `${kv.key}:${otlpValue(kv.value)}`)
+      .map((kv) => `${kv.key}:${otlpValue(kv.value)}`)
       .join(', ');
     return `Map(${items})`;
   }
   return 'Empty()';
 }
 
-function resourceLines(attrs: Json[] = []): string {
+function resourceLines(attrs: OtlpKeyValue[] = []): string {
   const lines = attrs.map((a) => `     -> ${a.key}: ${otlpValue(a.value)}`);
   return `Resource attributes:\n${lines.join('\n')}\n`;
 }
 
-function attrLines(attrs: Json[] = [], indent: string): string {
+function attrLines(attrs: OtlpKeyValue[] = [], indent: string): string {
   if (!attrs.length) {
     return '';
   }
@@ -210,16 +222,16 @@ function severityLabel(n?: number): string {
   return `${names[Math.min(6, Math.ceil(n / 4))] || 'Unspecified'}(${n})`;
 }
 
-function debugTraces(body: Json): string {
+function debugTraces(body: ExportTraceServiceRequest): string {
   const out: string[] = [];
-  (body.resourceSpans ?? []).forEach((rs: Json, i: number) => {
+  (body.resourceSpans ?? []).forEach((rs, i) => {
     out.push(`ResourceSpans #${i}`, resourceLines(rs.resource?.attributes));
-    (rs.scopeSpans ?? []).forEach((ss: Json, j: number) => {
+    (rs.scopeSpans ?? []).forEach((ss, j) => {
       out.push(
         `ScopeSpans #${j}`,
         `InstrumentationScope ${ss.scope?.name ?? ''} ${ss.scope?.version ?? ''}`,
       );
-      (ss.spans ?? []).forEach((span: Json, k: number) => {
+      (ss.spans ?? []).forEach((span, k) => {
         out.push(
           `Span #${k}`,
           `    Trace ID       : ${span.traceId ?? ''}`,
@@ -238,16 +250,16 @@ function debugTraces(body: Json): string {
   return out.join('\n');
 }
 
-function debugLogs(body: Json): string {
+function debugLogs(body: ExportLogsServiceRequest): string {
   const out: string[] = [];
-  (body.resourceLogs ?? []).forEach((rl: Json, i: number) => {
+  (body.resourceLogs ?? []).forEach((rl, i) => {
     out.push(`ResourceLog #${i}`, resourceLines(rl.resource?.attributes));
-    (rl.scopeLogs ?? []).forEach((sl: Json, j: number) => {
+    (rl.scopeLogs ?? []).forEach((sl, j) => {
       out.push(
         `ScopeLogs #${j}`,
         `InstrumentationScope ${sl.scope?.name ?? ''} ${sl.scope?.version ?? ''}`,
       );
-      (sl.logRecords ?? []).forEach((log: Json, k: number) => {
+      (sl.logRecords ?? []).forEach((log, k) => {
         out.push(
           `LogRecord #${k}`,
           `    ObservedTimestamp : ${ts(log.observedTimeUnixNano)}`,
@@ -267,8 +279,9 @@ function debugLogs(body: Json): string {
 
 /** Format an intercepted request the way the collector's `debug` exporter would. */
 export function toCollectorDebug(req: IntakeRequest): string {
-  const body = req.raw as Json;
-  return req.signal === 'traces' ? debugTraces(body) : debugLogs(body);
+  return req.signal === 'traces'
+    ? debugTraces(req.raw as ExportTraceServiceRequest)
+    : debugLogs(req.raw as ExportLogsServiceRequest);
 }
 
 // ── Pub/sub ───────────────────────────────────────────────────────────────────
@@ -287,15 +300,17 @@ export function onIntake(cb: (req: IntakeRequest) => void): () => void {
  * Called by the MSW request handlers.
  */
 export function ingest(signal: Signal, url: string, text: string): void {
-  let body: Json;
+  let parsed: unknown;
   try {
-    body = JSON.parse(text);
+    parsed = JSON.parse(text);
   } catch {
     return;
   }
   const bytes = new TextEncoder().encode(text).length;
   const { resource, records } =
-    signal === 'traces' ? decodeTraces(body) : decodeLogs(body);
+    signal === 'traces'
+      ? decodeTraces(parsed as ExportTraceServiceRequest)
+      : decodeLogs(parsed as ExportLogsServiceRequest);
 
   const req: IntakeRequest = {
     id: ++seq,
@@ -305,13 +320,13 @@ export function ingest(signal: Signal, url: string, text: string): void {
     bytes,
     resource,
     records,
-    raw: body,
+    raw: parsed,
   };
 
   if (import.meta.env.DEV) {
     console.debug(
       `[intake] ${signal} · ${records.length} record(s) · ${bytes}B`,
-      body,
+      parsed,
     );
   }
   bus.dispatchEvent(new CustomEvent('intake', { detail: req }));


### PR DESCRIPTION
### Disclaimer

The sandbox UI now has redundancy between the `Event Log` and `Intake received` sections, and the expand feature in `Intake received` isn't responsive... I'm happy to invest more time fixing this if the SIG considers the initiative worthwhile.

Also the recent e2e testing initiative https://github.com/open-telemetry/opentelemetry-browser/pull/332 has been merged which share quite some MSW approach with this PR.


## What

<img width="1501" height="471" alt="Screenshot 2026-07-10 at 17 22 41" src="https://github.com/user-attachments/assets/cbf33adf-5714-4ac8-9a88-370e5e911da1" />


Adds an in-browser "Intake received" panel to the sandbox that intercepts the
SDK's OTLP/HTTP exports with [MSW](https://mswjs.io/) and renders exactly what a
collector would receive over the wire — no backend, no CORS, no extra process.

It sits under the "Equivalent SDK init" panel, so you get a side-by-side of
*"here's the code / action"* → *"here's what got exported"*.

## Why

The sandbox could trigger telemetry but there was no way to see the resulting
export payloads without an external collector (and cross-origin exports to
`localhost:4318` would otherwise need CORS). MSW intercepts the request inside
the browser, so it works with zero setup — and, being fully client-side, it also
works on the deployed GitHub Pages showcase.

## How it works

- MSW handlers intercept `POST */v1/traces` and `*/v1/logs`, decode the OTLP JSON
  (AnyValue/KeyValue, span durations, `session.id`), and publish to the UI.
- The panel shows a request feed (batching + payload size + signal badge) →
  expand to see records grouped by instrumentation scope, each with duration,
  `trace=…`, and a `session=…` chip → per-request raw OTLP JSON toggle.

## Usage

- **Local:** `npm run dev` — enabled automatically in dev (single command, no
  extra process).
- **Deployed / any build:** append `?intake=mock` to the URL.
- Point the sandbox at a real collector (config form / query string) and the mock
  stays out of the way — it's dev/flag-gated so it never swallows real exports.