### PR TITLE
test(instrumentation): add console instrumentation e2e test

### DIFF
--- a/e2e-tests/packages/instrumentation/console/instrumentation.test.ts
+++ b/e2e-tests/packages/instrumentation/console/instrumentation.test.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { context, trace } from '@opentelemetry/api';
+import { ConsoleInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/console';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { collector } from '../../../utils/test-collector.ts';
+import type { TestSdkHandle } from '../../../utils/test-otel-setup.ts';
+import { testSdkSetup } from '../../../utils/test-otel-setup.ts';
+
+describe('ConsoleInstrumentation', () => {
+  let result: TestSdkHandle;
+
+  beforeAll(async () => {
+    await collector.start();
+  });
+
+  afterAll(() => {
+    collector.stop();
+  });
+
+  afterEach(async () => {
+    await result.shutdown();
+    collector.reset();
+  });
+
+  it('emits a log record with body, severity, and method attribute for console.error', async () => {
+    result = testSdkSetup([new ConsoleInstrumentation()]);
+
+    console.error('test browser error');
+
+    await vi.waitFor(
+      () => {
+        // Match by body, not index, so this stays resilient should unrelated console.logs later be added to the startBrowserSdk harness
+        const log = collector
+          .getLogs()
+          .find((l) => l.body?.stringValue === 'test browser error');
+        expect(log).toBeDefined();
+        if (!log) {
+          throw new Error('Log record is undefined');
+        }
+
+        const attr = (key: string) =>
+          log.attributes.find((a) => a.key === key)?.value;
+
+        expect(log.severityNumber).toBe(17); // SeverityNumber.ERROR
+        expect(log.severityText).toBe('error');
+        expect(log.eventName).toBe('browser.console');
+        expect(attr('browser.console.method')).toEqual({
+          stringValue: 'error',
+        });
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('maps each console method to its severity number', async () => {
+    result = testSdkSetup([new ConsoleInstrumentation()]);
+
+    console.debug('debug message');
+    console.log('log message');
+    console.info('info message');
+    console.warn('warn message');
+    console.error('error message');
+
+    // SeverityNumber: DEBUG=5, INFO=9, WARN=13, ERROR=17
+    const expected = [
+      ['debug message', 'debug', 5],
+      ['log message', 'log', 9],
+      ['info message', 'info', 9],
+      ['warn message', 'warn', 13],
+      ['error message', 'error', 17],
+    ] as const;
+
+    await vi.waitFor(
+      () => {
+        const logs = collector.getLogs();
+        for (const [body, method, severityNumber] of expected) {
+          const log = logs.find((l) => l.body?.stringValue === body);
+          expect(log?.severityText).toBe(method);
+          expect(log?.severityNumber).toBe(severityNumber);
+          expect(
+            log?.attributes.find((a) => a.key === 'browser.console.method')
+              ?.value,
+          ).toEqual({ stringValue: method });
+        }
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('serializes object arguments as JSON', async () => {
+    result = testSdkSetup([new ConsoleInstrumentation()]);
+
+    console.log('user', { id: 42 }, 'signed in');
+
+    await vi.waitFor(
+      () => {
+        const log = collector
+          .getLogs()
+          .find((l) => l.body?.stringValue === 'user {"id":42} signed in');
+        expect(log).toBeDefined();
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('only instruments the methods listed in logMethods', async () => {
+    result = testSdkSetup([
+      new ConsoleInstrumentation({ logMethods: ['error'] }),
+    ]);
+
+    console.log('log message');
+    console.warn('warn message');
+    console.error('error message');
+
+    await vi.waitFor(
+      () => {
+        const logs = collector.getLogs();
+        expect(
+          logs.find((l) => l.body?.stringValue === 'error message'),
+        ).toBeDefined();
+        expect(
+          logs.find((l) => l.body?.stringValue === 'log message'),
+        ).toBeUndefined();
+        expect(
+          logs.find((l) => l.body?.stringValue === 'warn message'),
+        ).toBeUndefined();
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('correlates the log with the active span', async () => {
+    result = testSdkSetup([new ConsoleInstrumentation()]);
+
+    const span = trace.getTracer('console-e2e').startSpan('checkout');
+    context.with(trace.setSpan(context.active(), span), () => {
+      console.error('charge failed');
+    });
+    span.end();
+
+    const { traceId, spanId } = span.spanContext();
+
+    await vi.waitFor(
+      () => {
+        const log = collector
+          .getLogs()
+          .find((l) => l.body?.stringValue === 'charge failed');
+        expect(log).toBeDefined();
+        if (!log) {
+          throw new Error('Log record is undefined');
+        }
+
+        expect(log.traceId).toBe(traceId);
+        expect(log.spanId).toBe(spanId);
+      },
+      { timeout: 2000 },
+    );
+  });
+});

--- a/e2e-tests/packages/instrumentation/errors/instrumentation.test.ts
+++ b/e2e-tests/packages/instrumentation/errors/instrumentation.test.ts
@@ -14,6 +14,7 @@ import {
   vi,
 } from 'vitest';
 import { collector } from '../../../utils/test-collector.ts';
+import type { TestSdkHandle } from '../../../utils/test-otel-setup.ts';
 import { testSdkSetup } from '../../../utils/test-otel-setup.ts';
 
 // Dispatch a synthetic error event without actually crashing the browser page.
@@ -41,7 +42,7 @@ const dispatchUnhandledRejection = (reason: Error | string) => {
 };
 
 describe('ErrorsInstrumentation', () => {
-  let result: ReturnType<typeof testSdkSetup>;
+  let result: TestSdkHandle;
 
   beforeAll(async () => {
     await collector.start();

--- a/e2e-tests/utils/test-collector.ts
+++ b/e2e-tests/utils/test-collector.ts
@@ -41,6 +41,8 @@ export interface OtlpLogRecord {
   spanId?: string;
   severityNumber?: number;
   severityText?: string;
+  eventName?: string;
+  body?: OtlpAnyValue;
   attributes: OtlpKeyValue[];
 }
 

--- a/e2e-tests/utils/test-otel-setup.ts
+++ b/e2e-tests/utils/test-otel-setup.ts
@@ -1,4 +1,4 @@
-import { trace } from '@opentelemetry/api';
+import { context, trace } from '@opentelemetry/api';
 import { logs } from '@opentelemetry/api-logs';
 import { startBrowserSdk } from '@opentelemetry/browser-sdk';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
@@ -6,10 +6,19 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { SimpleLogRecordProcessor } from '@opentelemetry/sdk-logs';
-import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-web';
+import {
+  SimpleSpanProcessor,
+  StackContextManager,
+} from '@opentelemetry/sdk-trace-web';
 import { COLLECTOR_URL, LOGS_COLLECTOR_URL } from './test-collector.ts';
 
-export function testSdkSetup(instrumentations: Instrumentation[]) {
+export interface TestSdkHandle {
+  shutdown: () => Promise<void>;
+}
+
+export function testSdkSetup(
+  instrumentations: Instrumentation[],
+): TestSdkHandle {
   const sdk = startBrowserSdk({
     logs: {
       processors: [
@@ -19,6 +28,7 @@ export function testSdkSetup(instrumentations: Instrumentation[]) {
       ],
     },
     traces: {
+      contextManager: new StackContextManager().enable(),
       processors: [
         new SimpleSpanProcessor(new OTLPTraceExporter({ url: COLLECTOR_URL })),
       ],
@@ -33,6 +43,7 @@ export function testSdkSetup(instrumentations: Instrumentation[]) {
       deregister();
       logs.disable();
       trace.disable();
+      context.disable();
     },
   };
 }

--- a/e2e-tests/vitest.config.ts
+++ b/e2e-tests/vitest.config.ts
@@ -24,6 +24,13 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      '@opentelemetry/browser-instrumentation/experimental/console':
+        fileURLToPath(
+          new URL(
+            '../packages/instrumentation/src/console/index.ts',
+            import.meta.url,
+          ),
+        ),
       '@opentelemetry/browser-instrumentation/experimental/errors':
         fileURLToPath(
           new URL(


### PR DESCRIPTION
## Which problem is this PR solving?

This adds end-to-end coverage for `ConsoleInstrumentation`, building on the e2e testing initiative from #332. This is test-only, no runtime/source changes.

## Short description of the changes

- Adds `ConsoleInstrumentation` e2e tests (`e2e-tests/packages/instrumentation/console/`)
     driving the real browser `console` through the SDK → OTLP/HTTP → MSW-mocked
     collector pipeline, covering:
     - body, severity number/text, `browser.console` event name, `browser.console.method` attribute
     - severity mapping across all five methods (debug/log/info/warn/error)
     - object-argument JSON serialization
     - `logMethods` config (only configured methods emit)
     - trace↔log correlation (a `console.*` call inside an active span yields a log
       carrying the span's `traceId`/`spanId`)
   - Extends shared `test-collector.ts` OTLP log type with `body`/`eventName` (already on the wire).
   - Adds a `StackContextManager` in `test-otel-setup.ts` so trace context propagates
     (needed for the correlation test); names its return type `TestSdkHandle` and
     migrates the `errors` e2e test onto it.
   - Adds the `console` source alias to `e2e-tests/vitest.config.ts`.

   Assertions match records by body, so any potential future unrelated logs emitted in the same window
   won't cause flakes. 

## Type of change

   - [x] Test-only change (no runtime behavior change)
   
 ## How Has This Been Tested?
   
   `npm run test:e2e`