### PR TITLE
feat(user-action): add callback function to create custom attributes in user action logs

### DIFF
--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -194,9 +194,23 @@ By default the instrumentation captures `click` events. You can configure which 
 
 ```typescript
 new UserActionInstrumentation({
-  autoCapturedActions: [], // default is ['click']
+  // Array of actions to automatically capture. Default: ['click'].
+  autoCapturedActions: [],
+
+  // Mutate the log record before it is emitted (e.g. attach custom attributes).
+  applyCustomLogRecordData: (logRecord) => {
+    logRecord.attributes = {
+      ...logRecord.attributes,
+      'app.user.role': 'admin',
+    };
+  },
 });
 ```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `autoCapturedActions` | `AutoCapturedUserAction[]` | `['click']` | Array of actions to automatically capture. |
+| `applyCustomLogRecordData` | `(logRecord: LogRecord) => void` | — | Hook to modify log records before they are emitted. Errors thrown from this hook are caught and logged via the instrumentation diag logger. |
 
 #### Additional Attributes
 

--- a/packages/instrumentation/src/user-action/instrumentation.test.ts
+++ b/packages/instrumentation/src/user-action/instrumentation.test.ts
@@ -6,7 +6,7 @@
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupTestLogExporter } from '#utils/test';
 import { UserActionInstrumentation } from './instrumentation.ts';
 
@@ -141,5 +141,62 @@ describe('UserActionInstrumentation', () => {
 
     const logs = inMemoryExporter.getFinishedLogRecords();
     expect(logs.length).toBe(0);
+  });
+
+  describe('applyCustomLogRecordData hook', () => {
+    it('should allow hook to add custom attributes', () => {
+      disableInstrumentations();
+      const customInstrumentation = new UserActionInstrumentation({
+        applyCustomLogRecordData: (logRecord) => {
+          logRecord.attributes = {
+            ...logRecord.attributes,
+            'custom.attribute': 'custom-value',
+          };
+        },
+      });
+      disableInstrumentations = registerInstrumentations({
+        instrumentations: [customInstrumentation],
+      });
+
+      const element = createTestElement();
+      dispatchMouseDownEvent(element, 0); // Left click
+
+      const logs = inMemoryExporter.getFinishedLogRecords();
+      expect(logs.length).toBe(1);
+
+      const log = logs[0];
+      expect(log?.attributes['custom.attribute']).toBe('custom-value');
+    });
+
+    it('should catch errors thrown by the hook and still emit', () => {
+      disableInstrumentations();
+      const customInstrumentation = new UserActionInstrumentation({
+        applyCustomLogRecordData: () => {
+          throw new Error('hook boom');
+        },
+      });
+      const diagErrorSpy = vi
+        .spyOn(
+          (
+            customInstrumentation as unknown as {
+              _diag: { error: (...a: unknown[]) => void };
+            }
+          )._diag,
+          'error',
+        )
+        .mockImplementation(() => { });
+
+      disableInstrumentations = registerInstrumentations({
+        instrumentations: [customInstrumentation],
+      });
+
+      const element = createTestElement();
+
+      dispatchMouseDownEvent(element, 0); // Left click
+
+      const logs = inMemoryExporter.getFinishedLogRecords();
+      expect(logs.length).toBe(1);
+      expect(diagErrorSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/instrumentation/src/user-action/instrumentation.test.ts
+++ b/packages/instrumentation/src/user-action/instrumentation.test.ts
@@ -6,7 +6,15 @@
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { setupTestLogExporter } from '#utils/test';
 import { UserActionInstrumentation } from './instrumentation.ts';
 
@@ -184,7 +192,7 @@ describe('UserActionInstrumentation', () => {
           )._diag,
           'error',
         )
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
 
       disableInstrumentations = registerInstrumentations({
         instrumentations: [customInstrumentation],

--- a/packages/instrumentation/src/user-action/instrumentation.ts
+++ b/packages/instrumentation/src/user-action/instrumentation.ts
@@ -104,12 +104,11 @@ export class UserActionInstrumentation extends InstrumentationBase<UserActionIns
   }
 
   private _applyCustomLogRecordData(logRecord: LogRecord) {
-    const applyCustomLogRecordData =
-      this.getConfig().applyCustomLogRecordData;
+    const applyCustomLogRecordData = this.getConfig().applyCustomLogRecordData;
     if (applyCustomLogRecordData) {
       safeExecuteInTheMiddle(
         () => applyCustomLogRecordData(logRecord),
-        error => {
+        (error) => {
           if (error) {
             this._diag.error('applyCustomLogRecordData hook failed', error);
           }

--- a/packages/instrumentation/src/user-action/instrumentation.ts
+++ b/packages/instrumentation/src/user-action/instrumentation.ts
@@ -2,9 +2,12 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import type { LogRecord } from '@opentelemetry/api-logs';
 import { SeverityNumber } from '@opentelemetry/api-logs';
-import { InstrumentationBase } from '@opentelemetry/instrumentation';
+import {
+  InstrumentationBase,
+  safeExecuteInTheMiddle,
+} from '@opentelemetry/instrumentation';
 import { getElementCSSSelector } from '#utils';
 import { version } from '../../package.json' with { type: 'json' };
 import {
@@ -82,7 +85,7 @@ export class UserActionInstrumentation extends InstrumentationBase<UserActionIns
       }
     }
 
-    this.logger.emit({
+    const logRecord: LogRecord = {
       severityNumber: SeverityNumber.INFO,
       eventName: CLICK_EVENT_NAME,
       attributes: {
@@ -93,7 +96,27 @@ export class UserActionInstrumentation extends InstrumentationBase<UserActionIns
         [ATTR_MOUSE_EVENT_BUTTON]: this._getMouseButtonFromMouseEvent(event),
         [ATTR_CSS_SELECTOR]: cssSelector,
       },
-    });
+    };
+
+    this._applyCustomLogRecordData(logRecord);
+
+    this.logger.emit(logRecord);
+  }
+
+  private _applyCustomLogRecordData(logRecord: LogRecord) {
+    const applyCustomLogRecordData =
+      this.getConfig().applyCustomLogRecordData;
+    if (applyCustomLogRecordData) {
+      safeExecuteInTheMiddle(
+        () => applyCustomLogRecordData(logRecord),
+        error => {
+          if (error) {
+            this._diag.error('applyCustomLogRecordData hook failed', error);
+          }
+        },
+        true,
+      );
+    }
   }
 
   override enable(): void {

--- a/packages/instrumentation/src/user-action/types.ts
+++ b/packages/instrumentation/src/user-action/types.ts
@@ -2,16 +2,20 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import type { LogRecord } from '@opentelemetry/api-logs';
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
 export type AutoCapturedUserAction = 'click';
 
 export type MouseButton = 'left' | 'middle' | 'right';
 
+export type ApplyCustomLogRecordDataFunction = (logRecord: LogRecord) => void;
+
 /**
  * UserActionInstrumentation Configuration
  */
 export interface UserActionInstrumentationConfig extends InstrumentationConfig {
   autoCapturedActions?: AutoCapturedUserAction[];
+  /** Hook to modify log records before they are emitted. */
+  applyCustomLogRecordData?: ApplyCustomLogRecordDataFunction;
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

In other instrumentation packages (navigation, web-vitals, etc), the applyCustomLogRecordData hook allows custom attributes to be attached to logs. This hook does not exist in the user-action instrumentation; this change adds this hook into the user-action instrumentation with the appropriate tests. The goal is to provide consistency in adding custom attributes to any logs generated across instrumentation packages.

## Short description of the changes

- adds the applyCustomLogRecordData hook to UserActionInstrumentationConfig
- safely executes this hook on the generated log record in the event of a click
- tests the success and failure cases of the hook

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] if the applyCustomLogRecordData hook is present in the config passed into UserActionInstrumentation, ensure that the custom attributes it creates are in the log record
- [x] if the applyCustomLogRecordData hook throws an error, ensure that the user action log is still emitted and the error is logged via diagnostics logger

These two tests are in packages/instrumentation/src/user-action/instrumentation.test.ts.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
