### PR TITLE
fix(sdk): accept sampler option in traces SDK

### DIFF
--- a/packages/sdk/src/traces/startTracesSdk.test.ts
+++ b/packages/sdk/src/traces/startTracesSdk.test.ts
@@ -4,7 +4,10 @@
  */
 
 import { diag, trace } from '@opentelemetry/api';
-import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace';
+import {
+  AlwaysOffSampler,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace';
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import type { WebSdk } from '../core/types.ts';
 import { startTracesSdk } from './startTracesSdk.ts';
@@ -245,5 +248,23 @@ describe('startTracesSdk', () => {
     expect(exportCalled).toStrictEqual(true);
     expect(fetchSpy).toHaveBeenCalled();
     expect(fetchSpy.mock.lastCall?.[0]).toEqual(url);
+  });
+
+  it('should accept a Sampler from the user', async () => {
+    // Act
+    tracesSdk = startTracesSdk({
+      batchProcessorConfig: {
+        // NOTE: we set a short delay to speed up tests and avoid test timeouts
+        scheduledDelayMillis: BSP_SCHEDULE_DELAY,
+      },
+      serviceName: 'test-service',
+      serviceVersion: '1.0.0',
+      sampler: new AlwaysOffSampler(),
+    });
+    trace.getTracer('traces-sdk-test').startSpan('test').end();
+    await new Promise((r) => setTimeout(r, BSP_SCHEDULE_DELAY + 5));
+
+    // Assert
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/sdk/src/traces/startTracesSdk.ts
+++ b/packages/sdk/src/traces/startTracesSdk.ts
@@ -75,12 +75,10 @@ export function startTracesSdk(config?: TracesConfig): WebSdk {
     return NOOP_SDK;
   }
   const tracerProvider = new TracerProvider({
-    // sampler: new TraceIdRatioBasedSampler(
-    //   typeof config?.sampleRate === "number" ? config?.sampleRate : 1,
-    // ),
     resource,
     spanLimits: config?.spanLimits,
     spanProcessors,
+    sampler: config?.sampler,
   });
   trace.setGlobalTracerProvider(tracerProvider);
 


### PR DESCRIPTION
## Which problem is this PR solving?

The sampler option is available in the traces SDK configuration but the implementation never used it to configure the tracer provider. The code was commented in in a `TODO` for a further discussion ([ref](https://github.com/open-telemetry/opentelemetry-browser/blob/533fcdf72db5eed6158b9e2bc42deb2452236d98/packages/sdk/src/traces/startTracesSdk.ts#L78-80)).

This PR adds the support for a sampler option and includes a test.

## Short description of the changes

- pass sampler configuration to `TracerProvider` when calling the constructor.
- add a test to check the sampler is working.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] unit test

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been added
