### PR TITLE
test: use browser sdk context manager in e2e setup

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -11,7 +11,7 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
     "@opentelemetry/instrumentation": "^0.221.0",
     "@opentelemetry/sdk-logs": "^0.221.0",
-    "@opentelemetry/sdk-trace-web": "^2.10.0",
+    "@opentelemetry/sdk-trace": "^2.10.0",
     "msw": "^2.15.0"
   }
 }

--- a/e2e-tests/utils/test-otel-setup.ts
+++ b/e2e-tests/utils/test-otel-setup.ts
@@ -1,9 +1,6 @@
 import { context, trace } from '@opentelemetry/api';
 import { logs } from '@opentelemetry/api-logs';
-import {
-  getDefaultContextManager,
-  startBrowserSdk,
-} from '@opentelemetry/browser-sdk';
+import { startBrowserSdk } from '@opentelemetry/browser-sdk';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import type { Instrumentation } from '@opentelemetry/instrumentation';
@@ -28,7 +25,6 @@ export function testSdkSetup(
       ],
     },
     traces: {
-      contextManager: getDefaultContextManager().enable(),
       processors: [
         new SimpleSpanProcessor({
           exporter: new OTLPTraceExporter({ url: COLLECTOR_URL }),

--- a/e2e-tests/utils/test-otel-setup.ts
+++ b/e2e-tests/utils/test-otel-setup.ts
@@ -1,15 +1,15 @@
 import { context, trace } from '@opentelemetry/api';
 import { logs } from '@opentelemetry/api-logs';
-import { startBrowserSdk } from '@opentelemetry/browser-sdk';
+import {
+  getDefaultContextManager,
+  startBrowserSdk,
+} from '@opentelemetry/browser-sdk';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { SimpleLogRecordProcessor } from '@opentelemetry/sdk-logs';
-import {
-  SimpleSpanProcessor,
-  StackContextManager,
-} from '@opentelemetry/sdk-trace-web';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace';
 import { COLLECTOR_URL, LOGS_COLLECTOR_URL } from './test-collector.ts';
 
 export interface TestSdkHandle {
@@ -28,9 +28,11 @@ export function testSdkSetup(
       ],
     },
     traces: {
-      contextManager: new StackContextManager().enable(),
+      contextManager: getDefaultContextManager().enable(),
       processors: [
-        new SimpleSpanProcessor(new OTLPTraceExporter({ url: COLLECTOR_URL })),
+        new SimpleSpanProcessor({
+          exporter: new OTLPTraceExporter({ url: COLLECTOR_URL }),
+        }),
       ],
     },
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
         "@opentelemetry/instrumentation": "^0.221.0",
         "@opentelemetry/sdk-logs": "^0.221.0",
-        "@opentelemetry/sdk-trace-web": "^2.10.0",
+        "@opentelemetry/sdk-trace": "^2.10.0",
         "msw": "^2.15.0"
       }
     },

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { getDefaultContextManager } from './core/context.ts';
 export type {
   LogsConfig,
   RootConfig,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export { getDefaultContextManager } from './core/context.ts';
 export type {
   LogsConfig,
   RootConfig,


### PR DESCRIPTION
## Summary
- export `getDefaultContextManager` from `@opentelemetry/browser-sdk`
- update the e2e setup to use that browser-sdk context manager instead of importing `StackContextManager` from `@opentelemetry/sdk-trace-web`
- switch e2e tests to `@opentelemetry/sdk-trace` for `SimpleSpanProcessor`

Closes #386.

## Verification
- `PATH=/tmp/npm-shim:/root/.local/node24/node-v24.15.0-linux-x64/bin:$PATH npm run build --workspace @opentelemetry/browser-sdk`
- `PATH=/tmp/npm-shim:/root/.local/node24/node-v24.15.0-linux-x64/bin:$PATH npm run check:tsc -- --filter=@opentelemetry/browser-sdk --filter=e2e-tests`
- `PATH=/tmp/npm-shim:/root/.local/node24/node-v24.15.0-linux-x64/bin:$PATH npm run test:e2e`
- `PATH=/tmp/npm-shim:/root/.local/node24/node-v24.15.0-linux-x64/bin:$PATH npm run lint:ci`
