### PR TITLE
feat: add e2e tests for fetch instrumentation

### DIFF
--- a/e2e-tests/packages/instrumentation/console/instrumentation.test.ts
+++ b/e2e-tests/packages/instrumentation/console/instrumentation.test.ts
@@ -5,15 +5,7 @@
 
 import { context, trace } from '@opentelemetry/api';
 import { ConsoleInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/console';
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { collector } from '../../../utils/test-collector.ts';
 import type { TestSdkHandle } from '../../../utils/test-otel-setup.ts';
 import { testSdkSetup } from '../../../utils/test-otel-setup.ts';
@@ -21,17 +13,8 @@ import { testSdkSetup } from '../../../utils/test-otel-setup.ts';
 describe('ConsoleInstrumentation', () => {
   let result: TestSdkHandle;
 
-  beforeAll(async () => {
-    await collector.start();
-  });
-
-  afterAll(() => {
-    collector.stop();
-  });
-
   afterEach(async () => {
     await result.shutdown();
-    collector.reset();
   });
 
   it('emits a log record with body, severity, and method attribute for console.error', async () => {

--- a/e2e-tests/packages/instrumentation/errors/instrumentation.test.ts
+++ b/e2e-tests/packages/instrumentation/errors/instrumentation.test.ts
@@ -4,15 +4,7 @@
  */
 
 import { ErrorsInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/errors';
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { collector } from '../../../utils/test-collector.ts';
 import type { TestSdkHandle } from '../../../utils/test-otel-setup.ts';
 import { testSdkSetup } from '../../../utils/test-otel-setup.ts';
@@ -44,17 +36,8 @@ const dispatchUnhandledRejection = (reason: Error | string) => {
 describe('ErrorsInstrumentation', () => {
   let result: TestSdkHandle;
 
-  beforeAll(async () => {
-    await collector.start();
-  });
-
-  afterAll(() => {
-    collector.stop();
-  });
-
   afterEach(async () => {
     await result.shutdown();
-    collector.reset();
   });
 
   it('emits a log record with exception attributes when an Error is thrown', async () => {

--- a/e2e-tests/packages/instrumentation/fetch/instrumentation.test.ts
+++ b/e2e-tests/packages/instrumentation/fetch/instrumentation.test.ts
@@ -1,0 +1,374 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { context, trace } from '@opentelemetry/api';
+import { FetchInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/fetch';
+import { ResourceTimingInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/resource-timing';
+import {
+  ATTR_ERROR_TYPE,
+  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_HTTP_RESPONSE_STATUS_CODE,
+  ATTR_SERVER_ADDRESS,
+  ATTR_SERVER_PORT,
+  ATTR_URL_FULL,
+} from '@opentelemetry/semantic-conventions';
+import { HttpResponse, http } from 'msw';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockServer } from '../../../utils/mock-server.ts';
+import {
+  COLLECTOR_URL,
+  collector,
+  LOGS_COLLECTOR_URL,
+} from '../../../utils/test-collector.ts';
+import type { TestSdkHandle } from '../../../utils/test-otel-setup.ts';
+import { testSdkSetup } from '../../../utils/test-otel-setup.ts';
+
+// The SDK exports spans/logs over real HTTP via fetch(). Without excluding
+// the collector endpoints, FetchInstrumentation would create a span for each
+// export call, which would itself need exporting, recursing forever.
+const IGNORE_COLLECTOR_URLS = [COLLECTOR_URL, LOGS_COLLECTOR_URL];
+
+const getUrlForPath = (path: string) => new URL(path, location.href).href;
+
+// This test's own fake application endpoints, unrelated to the OTLP collector.
+const fetchHandlers = [
+  http.get('/e2e/fetch/get', () => HttpResponse.json({ ok: true })),
+  http.get(
+    '/e2e/fetch/error',
+    () =>
+      new HttpResponse(null, {
+        status: 500,
+        statusText: 'Internal Server Error',
+      }),
+  ),
+  http.get('/e2e/fetch/network-error', () => HttpResponse.error()),
+  http.get('/e2e/fetch/abort', () => HttpResponse.json({ ok: true })),
+  http.get('/e2e/fetch/child', () => HttpResponse.json({ ok: true })),
+  http.get('/e2e/fetch/resource-correlation', () =>
+    HttpResponse.json({ ok: true }),
+  ),
+  http.get('/e2e/fetch/relative-resource-correlation', () =>
+    HttpResponse.json({ ok: true }),
+  ),
+];
+
+describe('FetchInstrumentation', () => {
+  let result: TestSdkHandle;
+
+  beforeEach(() => {
+    mockServer.use(...fetchHandlers);
+  });
+
+  afterEach(async () => {
+    await result.shutdown();
+  });
+
+  it('creates a span for a fetch request', async () => {
+    result = testSdkSetup([
+      new FetchInstrumentation({ ignoreUrls: IGNORE_COLLECTOR_URLS }),
+    ]);
+
+    const url = getUrlForPath('/e2e/fetch/get');
+    await fetch(url);
+
+    await vi.waitFor(
+      () => {
+        const span = collector
+          .getSpans()
+          .find(
+            (s) =>
+              s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
+                .stringValue === url,
+          );
+        expect(span).toBeDefined();
+        if (!span) {
+          throw new Error('Span is undefined');
+        }
+
+        const attr = (key: string) =>
+          span.attributes.find((a) => a.key === key)?.value;
+
+        expect(attr(ATTR_HTTP_REQUEST_METHOD)).toEqual({
+          stringValue: 'GET',
+        });
+        expect(attr(ATTR_SERVER_ADDRESS)).toEqual({
+          stringValue: location.hostname,
+        });
+        expect(attr(ATTR_SERVER_PORT)).toBeDefined();
+        expect(attr(ATTR_HTTP_RESPONSE_STATUS_CODE)).toEqual({
+          intValue: 200,
+        });
+        expect(span.status.code).toBe(0); // SpanStatusCode.UNSET
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('sets the span status to error for a non-2xx response', async () => {
+    result = testSdkSetup([
+      new FetchInstrumentation({ ignoreUrls: IGNORE_COLLECTOR_URLS }),
+    ]);
+
+    const url = getUrlForPath('/e2e/fetch/error');
+    await fetch(url);
+
+    await vi.waitFor(
+      () => {
+        const span = collector
+          .getSpans()
+          .find(
+            (s) =>
+              s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
+                .stringValue === url,
+          );
+        expect(span).toBeDefined();
+        if (!span) {
+          throw new Error('Span is undefined');
+        }
+
+        const attr = (key: string) =>
+          span.attributes.find((a) => a.key === key)?.value;
+
+        expect(attr(ATTR_HTTP_RESPONSE_STATUS_CODE)).toEqual({
+          intValue: 500,
+        });
+        // Per https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status,
+        // error.type is the status code as a string when a response was received.
+        expect(attr(ATTR_ERROR_TYPE)).toEqual({
+          stringValue: '500',
+        });
+        expect(span.status.code).toBe(2); // SpanStatusCode.ERROR
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('ends the span with an error status when the request fails with a network error', async () => {
+    result = testSdkSetup([
+      new FetchInstrumentation({ ignoreUrls: IGNORE_COLLECTOR_URLS }),
+    ]);
+
+    const url = getUrlForPath('/e2e/fetch/network-error');
+    await expect(fetch(url)).rejects.toThrow();
+
+    await vi.waitFor(
+      () => {
+        const span = collector
+          .getSpans()
+          .find(
+            (s) =>
+              s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
+                .stringValue === url,
+          );
+        expect(span).toBeDefined();
+        if (!span) {
+          throw new Error('Span is undefined');
+        }
+
+        const attr = (key: string) =>
+          span.attributes.find((a) => a.key === key)?.value;
+
+        // Per https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status,
+        // http.response.status_code is only set if a response was actually received,
+        // and error.type is the exception's name (a browser fetch() network
+        // failure always rejects with a TypeError), not its message.
+        expect(attr(ATTR_HTTP_RESPONSE_STATUS_CODE)).toBeUndefined();
+        expect(attr(ATTR_ERROR_TYPE)).toEqual({ stringValue: 'TypeError' });
+        expect(span.status.code).toBe(2); // SpanStatusCode.ERROR
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('does not record an error when the request is intentionally aborted', async () => {
+    result = testSdkSetup([
+      new FetchInstrumentation({ ignoreUrls: IGNORE_COLLECTOR_URLS }),
+    ]);
+
+    const url = getUrlForPath('/e2e/fetch/abort');
+    const controller = new AbortController();
+    const fetchPromise = fetch(url, { signal: controller.signal });
+    controller.abort();
+
+    await expect(fetchPromise).rejects.toThrow();
+
+    await vi.waitFor(
+      () => {
+        const span = collector
+          .getSpans()
+          .find(
+            (s) =>
+              s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
+                .stringValue === url,
+          );
+        expect(span).toBeDefined();
+        if (!span) {
+          throw new Error('Span is undefined');
+        }
+
+        const attr = (key: string) =>
+          span.attributes.find((a) => a.key === key)?.value;
+
+        // Per https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status,
+        // an intentional cancellation by the caller is not an error: no
+        // status code, no error.type, and the span status stays unset.
+        expect(attr(ATTR_HTTP_RESPONSE_STATUS_CODE)).toBeUndefined();
+        expect(attr(ATTR_ERROR_TYPE)).toBeUndefined();
+        expect(span.status.code).toBe(0); // SpanStatusCode.UNSET
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('creates the fetch span as a child of the currently active span', async () => {
+    result = testSdkSetup([
+      new FetchInstrumentation({ ignoreUrls: IGNORE_COLLECTOR_URLS }),
+    ]);
+
+    const parentSpan = trace
+      .getTracer('fetch-e2e')
+      .startSpan('parent-operation');
+    const url = getUrlForPath('/e2e/fetch/child');
+
+    await context.with(trace.setSpan(context.active(), parentSpan), () =>
+      fetch(url),
+    );
+    parentSpan.end();
+
+    const { traceId, spanId } = parentSpan.spanContext();
+
+    await vi.waitFor(
+      () => {
+        const span = collector
+          .getSpans()
+          .find(
+            (s) =>
+              s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
+                .stringValue === url,
+          );
+        expect(span).toBeDefined();
+        if (!span) {
+          throw new Error('Span is undefined');
+        }
+
+        expect(span.traceId).toBe(traceId);
+        expect(span.parentSpanId).toBe(spanId);
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('stores the network context so a resource timing entry can be correlated with the fetch span', async () => {
+    result = testSdkSetup([
+      new FetchInstrumentation({ ignoreUrls: IGNORE_COLLECTOR_URLS }),
+      new ResourceTimingInstrumentation({
+        ignoreUrls: IGNORE_COLLECTOR_URLS,
+        // The default PerformanceObserver replays every buffered resource on
+        // the page (scripts, HMR, etc.), not just this test's fetch() calls.
+        // Scope it down so the assertions below only ever see our own request.
+        initiatorTypes: ['fetch'],
+      }),
+    ]);
+
+    const url = getUrlForPath('/e2e/fetch/resource-correlation');
+    await fetch(url);
+
+    const span = await vi.waitFor(
+      () => {
+        const found = collector
+          .getSpans()
+          .find(
+            (s) =>
+              s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
+                .stringValue === url,
+          );
+        expect(found).toBeDefined();
+        return found;
+      },
+      { timeout: 2000 },
+    );
+    if (!span) {
+      throw new Error('Span is undefined');
+    }
+
+    await vi.waitFor(
+      () => {
+        const log = collector
+          .getLogs()
+          .find(
+            (l) =>
+              l.eventName === 'browser.resource_timing' &&
+              l.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
+                .stringValue === url,
+          );
+        expect(log).toBeDefined();
+        if (!log) {
+          throw new Error('Log record is undefined');
+        }
+
+        expect(log.traceId).toBe(span.traceId);
+        expect(log.spanId).toBe(span.spanId);
+      },
+      { timeout: 5000 },
+    );
+  });
+
+  it('correlates the resource timing entry when fetch is called with a relative URL', async () => {
+    result = testSdkSetup([
+      new FetchInstrumentation({ ignoreUrls: IGNORE_COLLECTOR_URLS }),
+      new ResourceTimingInstrumentation({
+        ignoreUrls: IGNORE_COLLECTOR_URLS,
+        initiatorTypes: ['fetch'],
+      }),
+    ]);
+
+    // Call fetch() with a relative URL. The browser always reports resource
+    // timing entries with the resolved absolute URL, so this only correlates
+    // if FetchInstrumentation registers the network context under the same
+    // absolute URL it resolves internally, rather than the raw relative input.
+    const relativeUrl = '/e2e/fetch/relative-resource-correlation';
+    const absoluteUrl = getUrlForPath(relativeUrl);
+    await fetch(relativeUrl);
+
+    const span = await vi.waitFor(
+      () => {
+        const found = collector
+          .getSpans()
+          .find(
+            (s) =>
+              s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
+                .stringValue === absoluteUrl,
+          );
+        expect(found).toBeDefined();
+        return found;
+      },
+      { timeout: 2000 },
+    );
+    if (!span) {
+      throw new Error('Span is undefined');
+    }
+
+    await vi.waitFor(
+      () => {
+        const log = collector
+          .getLogs()
+          .find(
+            (l) =>
+              l.eventName === 'browser.resource_timing' &&
+              l.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
+                .stringValue === absoluteUrl,
+          );
+        expect(log).toBeDefined();
+        if (!log) {
+          throw new Error('Log record is undefined');
+        }
+
+        expect(log.traceId).toBe(span.traceId);
+        expect(log.spanId).toBe(span.spanId);
+      },
+      { timeout: 5000 },
+    );
+  });
+});

--- a/e2e-tests/packages/instrumentation/fetch/instrumentation.test.ts
+++ b/e2e-tests/packages/instrumentation/fetch/instrumentation.test.ts
@@ -17,20 +17,40 @@ import {
 import { HttpResponse, http } from 'msw';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockServer } from '../../../utils/mock-server.ts';
-import {
-  COLLECTOR_URL,
-  collector,
-  LOGS_COLLECTOR_URL,
-} from '../../../utils/test-collector.ts';
+import { collector } from '../../../utils/test-collector.ts';
 import type { TestSdkHandle } from '../../../utils/test-otel-setup.ts';
 import { testSdkSetup } from '../../../utils/test-otel-setup.ts';
 
-// The SDK exports spans/logs over real HTTP via fetch(). Without excluding
-// the collector endpoints, FetchInstrumentation would create a span for each
-// export call, which would itself need exporting, recursing forever.
-const IGNORE_COLLECTOR_URLS = [COLLECTOR_URL, LOGS_COLLECTOR_URL];
-
 const getUrlForPath = (path: string) => new URL(path, location.href).href;
+
+const getSpanByUrl = (url: string) => {
+  const span = collector
+    .getSpans()
+    .find(
+      (s) =>
+        s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value.stringValue ===
+        url,
+    );
+  expect(span).toBeDefined();
+
+  // biome-ignore lint/style/noNonNullAssertion: expect(...).toBeDefined() above throws if undefined
+  return span!;
+};
+
+const getResourceTimingLogByUrl = (url: string) => {
+  const log = collector
+    .getLogs()
+    .find(
+      (l) =>
+        l.eventName === 'browser.resource_timing' &&
+        l.attributes.find((a) => a.key === ATTR_URL_FULL)?.value.stringValue ===
+          url,
+    );
+  expect(log).toBeDefined();
+
+  // biome-ignore lint/style/noNonNullAssertion: expect(...).toBeDefined() above throws if undefined
+  return log!;
+};
 
 // This test's own fake application endpoints, unrelated to the OTLP collector.
 const fetchHandlers = [
@@ -66,126 +86,73 @@ describe('FetchInstrumentation', () => {
   });
 
   it('creates a span for a fetch request', async () => {
-    result = testSdkSetup([
-      new FetchInstrumentation({ ignoreUrls: IGNORE_COLLECTOR_URLS }),
-    ]);
+    result = testSdkSetup([new FetchInstrumentation()]);
 
     const url = getUrlForPath('/e2e/fetch/get');
     await fetch(url);
 
-    await vi.waitFor(
-      () => {
-        const span = collector
-          .getSpans()
-          .find(
-            (s) =>
-              s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
-                .stringValue === url,
-          );
-        expect(span).toBeDefined();
-        if (!span) {
-          throw new Error('Span is undefined');
-        }
+    const span = await vi.waitFor(() => getSpanByUrl(url), { timeout: 2000 });
 
-        const attr = (key: string) =>
-          span.attributes.find((a) => a.key === key)?.value;
+    const attr = (key: string) =>
+      span.attributes.find((a) => a.key === key)?.value;
 
-        expect(attr(ATTR_HTTP_REQUEST_METHOD)).toEqual({
-          stringValue: 'GET',
-        });
-        expect(attr(ATTR_SERVER_ADDRESS)).toEqual({
-          stringValue: location.hostname,
-        });
-        expect(attr(ATTR_SERVER_PORT)).toBeDefined();
-        expect(attr(ATTR_HTTP_RESPONSE_STATUS_CODE)).toEqual({
-          intValue: 200,
-        });
-        expect(span.status.code).toBe(0); // SpanStatusCode.UNSET
-      },
-      { timeout: 2000 },
-    );
+    expect(attr(ATTR_HTTP_REQUEST_METHOD)).toEqual({
+      stringValue: 'GET',
+    });
+    expect(attr(ATTR_SERVER_ADDRESS)).toEqual({
+      stringValue: location.hostname,
+    });
+    expect(attr(ATTR_SERVER_PORT)).toBeDefined();
+    expect(attr(ATTR_HTTP_RESPONSE_STATUS_CODE)).toEqual({
+      intValue: 200,
+    });
+    expect(span.status.code).toBe(0); // SpanStatusCode.UNSET
   });
 
   it('sets the span status to error for a non-2xx response', async () => {
-    result = testSdkSetup([
-      new FetchInstrumentation({ ignoreUrls: IGNORE_COLLECTOR_URLS }),
-    ]);
+    result = testSdkSetup([new FetchInstrumentation()]);
 
     const url = getUrlForPath('/e2e/fetch/error');
     await fetch(url);
 
-    await vi.waitFor(
-      () => {
-        const span = collector
-          .getSpans()
-          .find(
-            (s) =>
-              s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
-                .stringValue === url,
-          );
-        expect(span).toBeDefined();
-        if (!span) {
-          throw new Error('Span is undefined');
-        }
+    const span = await vi.waitFor(() => getSpanByUrl(url), { timeout: 2000 });
 
-        const attr = (key: string) =>
-          span.attributes.find((a) => a.key === key)?.value;
+    const attr = (key: string) =>
+      span.attributes.find((a) => a.key === key)?.value;
 
-        expect(attr(ATTR_HTTP_RESPONSE_STATUS_CODE)).toEqual({
-          intValue: 500,
-        });
-        // Per https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status,
-        // error.type is the status code as a string when a response was received.
-        expect(attr(ATTR_ERROR_TYPE)).toEqual({
-          stringValue: '500',
-        });
-        expect(span.status.code).toBe(2); // SpanStatusCode.ERROR
-      },
-      { timeout: 2000 },
-    );
+    expect(attr(ATTR_HTTP_RESPONSE_STATUS_CODE)).toEqual({
+      intValue: 500,
+    });
+    // Per https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status,
+    // error.type is the status code as a string when a response was received.
+    expect(attr(ATTR_ERROR_TYPE)).toEqual({
+      stringValue: '500',
+    });
+    expect(span.status.code).toBe(2); // SpanStatusCode.ERROR
   });
 
   it('ends the span with an error status when the request fails with a network error', async () => {
-    result = testSdkSetup([
-      new FetchInstrumentation({ ignoreUrls: IGNORE_COLLECTOR_URLS }),
-    ]);
+    result = testSdkSetup([new FetchInstrumentation()]);
 
     const url = getUrlForPath('/e2e/fetch/network-error');
     await expect(fetch(url)).rejects.toThrow();
 
-    await vi.waitFor(
-      () => {
-        const span = collector
-          .getSpans()
-          .find(
-            (s) =>
-              s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
-                .stringValue === url,
-          );
-        expect(span).toBeDefined();
-        if (!span) {
-          throw new Error('Span is undefined');
-        }
+    const span = await vi.waitFor(() => getSpanByUrl(url), { timeout: 2000 });
 
-        const attr = (key: string) =>
-          span.attributes.find((a) => a.key === key)?.value;
+    const attr = (key: string) =>
+      span.attributes.find((a) => a.key === key)?.value;
 
-        // Per https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status,
-        // http.response.status_code is only set if a response was actually received,
-        // and error.type is the exception's name (a browser fetch() network
-        // failure always rejects with a TypeError), not its message.
-        expect(attr(ATTR_HTTP_RESPONSE_STATUS_CODE)).toBeUndefined();
-        expect(attr(ATTR_ERROR_TYPE)).toEqual({ stringValue: 'TypeError' });
-        expect(span.status.code).toBe(2); // SpanStatusCode.ERROR
-      },
-      { timeout: 2000 },
-    );
+    // Per https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status,
+    // http.response.status_code is only set if a response was actually received,
+    // and error.type is the exception's name (a browser fetch() network
+    // failure always rejects with a TypeError), not its message.
+    expect(attr(ATTR_HTTP_RESPONSE_STATUS_CODE)).toBeUndefined();
+    expect(attr(ATTR_ERROR_TYPE)).toEqual({ stringValue: 'TypeError' });
+    expect(span.status.code).toBe(2); // SpanStatusCode.ERROR
   });
 
   it('does not record an error when the request is intentionally aborted', async () => {
-    result = testSdkSetup([
-      new FetchInstrumentation({ ignoreUrls: IGNORE_COLLECTOR_URLS }),
-    ]);
+    result = testSdkSetup([new FetchInstrumentation()]);
 
     const url = getUrlForPath('/e2e/fetch/abort');
     const controller = new AbortController();
@@ -194,38 +161,21 @@ describe('FetchInstrumentation', () => {
 
     await expect(fetchPromise).rejects.toThrow();
 
-    await vi.waitFor(
-      () => {
-        const span = collector
-          .getSpans()
-          .find(
-            (s) =>
-              s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
-                .stringValue === url,
-          );
-        expect(span).toBeDefined();
-        if (!span) {
-          throw new Error('Span is undefined');
-        }
+    const span = await vi.waitFor(() => getSpanByUrl(url), { timeout: 2000 });
 
-        const attr = (key: string) =>
-          span.attributes.find((a) => a.key === key)?.value;
+    const attr = (key: string) =>
+      span.attributes.find((a) => a.key === key)?.value;
 
-        // Per https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status,
-        // an intentional cancellation by the caller is not an error: no
-        // status code, no error.type, and the span status stays unset.
-        expect(attr(ATTR_HTTP_RESPONSE_STATUS_CODE)).toBeUndefined();
-        expect(attr(ATTR_ERROR_TYPE)).toBeUndefined();
-        expect(span.status.code).toBe(0); // SpanStatusCode.UNSET
-      },
-      { timeout: 2000 },
-    );
+    // Per https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status,
+    // an intentional cancellation by the caller is not an error: no
+    // status code, no error.type, and the span status stays unset.
+    expect(attr(ATTR_HTTP_RESPONSE_STATUS_CODE)).toBeUndefined();
+    expect(attr(ATTR_ERROR_TYPE)).toBeUndefined();
+    expect(span.status.code).toBe(0); // SpanStatusCode.UNSET
   });
 
   it('creates the fetch span as a child of the currently active span', async () => {
-    result = testSdkSetup([
-      new FetchInstrumentation({ ignoreUrls: IGNORE_COLLECTOR_URLS }),
-    ]);
+    result = testSdkSetup([new FetchInstrumentation()]);
 
     const parentSpan = trace
       .getTracer('fetch-e2e')
@@ -239,32 +189,16 @@ describe('FetchInstrumentation', () => {
 
     const { traceId, spanId } = parentSpan.spanContext();
 
-    await vi.waitFor(
-      () => {
-        const span = collector
-          .getSpans()
-          .find(
-            (s) =>
-              s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
-                .stringValue === url,
-          );
-        expect(span).toBeDefined();
-        if (!span) {
-          throw new Error('Span is undefined');
-        }
+    const span = await vi.waitFor(() => getSpanByUrl(url), { timeout: 2000 });
 
-        expect(span.traceId).toBe(traceId);
-        expect(span.parentSpanId).toBe(spanId);
-      },
-      { timeout: 2000 },
-    );
+    expect(span.traceId).toBe(traceId);
+    expect(span.parentSpanId).toBe(spanId);
   });
 
   it('stores the network context so a resource timing entry can be correlated with the fetch span', async () => {
     result = testSdkSetup([
-      new FetchInstrumentation({ ignoreUrls: IGNORE_COLLECTOR_URLS }),
+      new FetchInstrumentation(),
       new ResourceTimingInstrumentation({
-        ignoreUrls: IGNORE_COLLECTOR_URLS,
         // The default PerformanceObserver replays every buffered resource on
         // the page (scripts, HMR, etc.), not just this test's fetch() calls.
         // Scope it down so the assertions below only ever see our own request.
@@ -275,51 +209,19 @@ describe('FetchInstrumentation', () => {
     const url = getUrlForPath('/e2e/fetch/resource-correlation');
     await fetch(url);
 
-    const span = await vi.waitFor(
-      () => {
-        const found = collector
-          .getSpans()
-          .find(
-            (s) =>
-              s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
-                .stringValue === url,
-          );
-        expect(found).toBeDefined();
-        return found;
-      },
-      { timeout: 2000 },
-    );
-    if (!span) {
-      throw new Error('Span is undefined');
-    }
+    const span = await vi.waitFor(() => getSpanByUrl(url), { timeout: 2000 });
+    const log = await vi.waitFor(() => getResourceTimingLogByUrl(url), {
+      timeout: 5000,
+    });
 
-    await vi.waitFor(
-      () => {
-        const log = collector
-          .getLogs()
-          .find(
-            (l) =>
-              l.eventName === 'browser.resource_timing' &&
-              l.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
-                .stringValue === url,
-          );
-        expect(log).toBeDefined();
-        if (!log) {
-          throw new Error('Log record is undefined');
-        }
-
-        expect(log.traceId).toBe(span.traceId);
-        expect(log.spanId).toBe(span.spanId);
-      },
-      { timeout: 5000 },
-    );
+    expect(log.traceId).toBe(span.traceId);
+    expect(log.spanId).toBe(span.spanId);
   });
 
   it('correlates the resource timing entry when fetch is called with a relative URL', async () => {
     result = testSdkSetup([
-      new FetchInstrumentation({ ignoreUrls: IGNORE_COLLECTOR_URLS }),
+      new FetchInstrumentation(),
       new ResourceTimingInstrumentation({
-        ignoreUrls: IGNORE_COLLECTOR_URLS,
         initiatorTypes: ['fetch'],
       }),
     ]);
@@ -332,43 +234,14 @@ describe('FetchInstrumentation', () => {
     const absoluteUrl = getUrlForPath(relativeUrl);
     await fetch(relativeUrl);
 
-    const span = await vi.waitFor(
-      () => {
-        const found = collector
-          .getSpans()
-          .find(
-            (s) =>
-              s.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
-                .stringValue === absoluteUrl,
-          );
-        expect(found).toBeDefined();
-        return found;
-      },
-      { timeout: 2000 },
-    );
-    if (!span) {
-      throw new Error('Span is undefined');
-    }
+    const span = await vi.waitFor(() => getSpanByUrl(absoluteUrl), {
+      timeout: 2000,
+    });
+    const log = await vi.waitFor(() => getResourceTimingLogByUrl(absoluteUrl), {
+      timeout: 5000,
+    });
 
-    await vi.waitFor(
-      () => {
-        const log = collector
-          .getLogs()
-          .find(
-            (l) =>
-              l.eventName === 'browser.resource_timing' &&
-              l.attributes.find((a) => a.key === ATTR_URL_FULL)?.value
-                .stringValue === absoluteUrl,
-          );
-        expect(log).toBeDefined();
-        if (!log) {
-          throw new Error('Log record is undefined');
-        }
-
-        expect(log.traceId).toBe(span.traceId);
-        expect(log.spanId).toBe(span.spanId);
-      },
-      { timeout: 5000 },
-    );
+    expect(log.traceId).toBe(span.traceId);
+    expect(log.spanId).toBe(span.spanId);
   });
 });

--- a/e2e-tests/utils/e2e-setup.ts
+++ b/e2e-tests/utils/e2e-setup.ts
@@ -1,0 +1,16 @@
+import { afterAll, afterEach, beforeAll } from 'vitest';
+import { mockServer } from './mock-server.ts';
+import { collector } from './test-collector.ts';
+
+beforeAll(async () => {
+  await mockServer.start(...collector.handlers);
+});
+
+afterEach(() => {
+  collector.reset();
+  mockServer.resetHandlers();
+});
+
+afterAll(() => {
+  mockServer.stop();
+});

--- a/e2e-tests/utils/mock-server.ts
+++ b/e2e-tests/utils/mock-server.ts
@@ -1,0 +1,27 @@
+import type { HttpHandler } from 'msw';
+import { setupWorker } from 'msw/browser';
+
+// A page can only have one active MSW Service Worker registration at a time,
+// so this is the single shared instance every test's HTTP mocking goes
+// through — including the OTLP collector (see test-collector.ts).
+let worker: ReturnType<typeof setupWorker> | undefined;
+
+export const mockServer = {
+  async start(...handlers: HttpHandler[]): Promise<void> {
+    worker = setupWorker(...handlers);
+    await worker.start({ onUnhandledRequest: 'error', quiet: true });
+  },
+
+  stop(): void {
+    worker?.stop();
+    worker = undefined;
+  },
+
+  resetHandlers(): void {
+    worker?.resetHandlers();
+  },
+
+  use(...handlers: HttpHandler[]): void {
+    worker?.use(...handlers);
+  },
+};

--- a/e2e-tests/utils/test-collector.ts
+++ b/e2e-tests/utils/test-collector.ts
@@ -1,6 +1,4 @@
-import type { HttpHandler } from 'msw';
 import { HttpResponse, http } from 'msw';
-import { setupWorker } from 'msw/browser';
 
 export const COLLECTOR_URL = 'http://localhost:4318/v1/traces';
 export const LOGS_COLLECTOR_URL = 'http://localhost:4318/v1/logs';
@@ -68,49 +66,26 @@ interface ExportLogsServiceRequest {
 
 // ── Internal singleton state ───────────────────────────────────────────────────
 
-let worker: ReturnType<typeof setupWorker> | undefined;
-let tracePayloads: ExportTraceServiceRequest[] = [];
-let logPayloads: ExportLogsServiceRequest[] = [];
+const tracePayloads: ExportTraceServiceRequest[] = [];
+const logPayloads: ExportLogsServiceRequest[] = [];
 
 // ── Collector ─────────────────────────────────────────────────────────────────
 
 export const collector = {
-  /** Start MSW and intercept OTLP exports. Call once in beforeAll. */
-  async start(): Promise<void> {
-    worker = setupWorker(
-      http.post(COLLECTOR_URL, async ({ request }) => {
-        tracePayloads.push((await request.json()) as ExportTraceServiceRequest);
-        return HttpResponse.json({});
-      }),
-      http.post(LOGS_COLLECTOR_URL, async ({ request }) => {
-        logPayloads.push((await request.json()) as ExportLogsServiceRequest);
-        return HttpResponse.json({});
-      }),
-    );
-    await worker.start({ onUnhandledRequest: 'error', quiet: true });
-  },
+  handlers: [
+    http.post(COLLECTOR_URL, async ({ request }) => {
+      tracePayloads.push((await request.json()) as ExportTraceServiceRequest);
+      return HttpResponse.json({});
+    }),
+    http.post(LOGS_COLLECTOR_URL, async ({ request }) => {
+      logPayloads.push((await request.json()) as ExportLogsServiceRequest);
+      return HttpResponse.json({});
+    }),
+  ],
 
-  /** Stop MSW and discard all captured data. Call once in afterAll. */
-  stop(): void {
-    worker?.stop();
-    worker = undefined;
-    tracePayloads = [];
-    logPayloads = [];
-  },
-
-  /**
-   * Clear captured payloads and remove any runtime handlers added via `use()`.
-   * Call in afterEach to isolate tests.
-   */
   reset(): void {
     tracePayloads.length = 0;
     logPayloads.length = 0;
-    worker?.resetHandlers();
-  },
-
-  /** Add runtime MSW handlers for the current test (cleared by reset()). */
-  use(...handlers: HttpHandler[]): void {
-    worker?.use(...handlers);
   },
 
   getSpans(): OtlpSpan[] {

--- a/e2e-tests/vitest.config.ts
+++ b/e2e-tests/vitest.config.ts
@@ -38,6 +38,20 @@ export default defineConfig({
             import.meta.url,
           ),
         ),
+      '@opentelemetry/browser-instrumentation/experimental/fetch':
+        fileURLToPath(
+          new URL(
+            '../packages/instrumentation/src/fetch/index.ts',
+            import.meta.url,
+          ),
+        ),
+      '@opentelemetry/browser-instrumentation/experimental/resource-timing':
+        fileURLToPath(
+          new URL(
+            '../packages/instrumentation/src/resource-timing/index.ts',
+            import.meta.url,
+          ),
+        ),
       '@opentelemetry/browser-sdk': fileURLToPath(
         new URL('../packages/sdk/src/index.ts', import.meta.url),
       ),
@@ -45,6 +59,7 @@ export default defineConfig({
   },
   test: {
     include: ['e2e-tests/**/*.test.ts'],
+    setupFiles: ['e2e-tests/utils/e2e-setup.ts'],
     browser: {
       provider: playwright(),
       enabled: true,

--- a/packages/instrumentation/src/fetch/instrumentation.test.ts
+++ b/packages/instrumentation/src/fetch/instrumentation.test.ts
@@ -24,7 +24,7 @@ import {
   ATTR_SERVER_PORT,
   ATTR_URL_FULL,
 } from '@opentelemetry/semantic-conventions';
-import { HttpResponse, http } from 'msw';
+import { delay, HttpResponse, http } from 'msw';
 import { setupWorker } from 'msw/browser';
 import type { Mock } from 'vitest';
 import {
@@ -67,6 +67,10 @@ export const handlers = [
   }),
   http.get('/api/network-error', () => {
     return HttpResponse.error();
+  }),
+  http.get('/api/slow', async () => {
+    await delay(200);
+    return HttpResponse.json({ ok: true });
   }),
   http.get(`${location.origin}/test.wasm`, () => {
     // Minimal valid WASM binary: magic number + version only.
@@ -128,6 +132,16 @@ export const handlers = [
     });
 
     return response;
+  }),
+  http.get('/api/broken-stream', () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('partial'));
+        setTimeout(() => controller.error(new Error('stream broke')), 10);
+      },
+    });
+
+    return new HttpResponse(stream, { status: 200 });
   }),
   http.get('http://example.com/api/status.json', () => {
     return HttpResponse.json({ ok: true });
@@ -458,6 +472,57 @@ describe('FetchInstrumentation', () => {
 
       // Context has been registered for the resource
       assertResourceRegistered({ span, url, startTime, endTime });
+    });
+
+    it('should record an error when the request is aborted by AbortSignal.timeout', async () => {
+      const url = getUrlForPath('/api/slow');
+      const startTime = performance.now();
+      const fetchPromise = fetch(url, { signal: AbortSignal.timeout(10) });
+      await expect(fetchPromise).rejects.toThrow();
+      const endTime = performance.now();
+
+      // Span is exported
+      const span = await waitForSpan(url);
+      expect(span.name).toBe('GET');
+      expect(span.kind).toEqual(SpanKind.CLIENT);
+      expect(span.attributes[ATTR_URL_FULL]).toEqual(url);
+      expect(span.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE]).toBeUndefined();
+      expect(span.attributes[ATTR_ERROR_TYPE]).toEqual('TimeoutError');
+      expect(span.status.code).toEqual(SpanStatusCode.ERROR);
+
+      // Context has been registered for the resource
+      assertResourceRegistered({ span, url, startTime, endTime });
+    });
+
+    it('should record the real status and an error when the body stream fails mid-read', async () => {
+      // The browser relays the mocked stream's error from the Service Worker
+      // to the page as an unhandled rejection independent of our own promise
+      // chain, so it needs suppressing here the same way dispatched `error`
+      // events are suppressed in the errors instrumentation tests.
+      const suppress = (e: PromiseRejectionEvent) => e.preventDefault();
+      window.addEventListener('unhandledrejection', suppress);
+
+      try {
+        const url = getUrlForPath('/api/broken-stream');
+        const startTime = performance.now();
+        const response = await fetch(url);
+        await expect(response.text()).rejects.toThrow();
+        const endTime = performance.now();
+
+        // Span is exported
+        const span = await waitForSpan(url);
+        expect(span.name).toBe('GET');
+        expect(span.kind).toEqual(SpanKind.CLIENT);
+        expect(span.attributes[ATTR_URL_FULL]).toEqual(url);
+        expect(span.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE]).toEqual(200);
+        expect(span.attributes[ATTR_ERROR_TYPE]).toEqual('TypeError');
+        expect(span.status.code).toEqual(SpanStatusCode.ERROR);
+
+        // Context has been registered for the resource
+        assertResourceRegistered({ span, url, startTime, endTime });
+      } finally {
+        window.removeEventListener('unhandledrejection', suppress);
+      }
     });
 
     it('204 (No Content) will correctly end the span', async () => {

--- a/packages/instrumentation/src/fetch/instrumentation.test.ts
+++ b/packages/instrumentation/src/fetch/instrumentation.test.ts
@@ -404,7 +404,7 @@ describe('FetchInstrumentation', () => {
       expect(span.attributes[ATTR_SERVER_PORT]).toEqual(VITEST_SERVER_PORT);
       expect(span.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE]).toEqual(500);
       expect(span.status.code).toEqual(SpanStatusCode.ERROR);
-      expect(span.attributes[ATTR_ERROR_TYPE]).toEqual('Internal Server Error');
+      expect(span.attributes[ATTR_ERROR_TYPE]).toEqual('500');
 
       // Context has been registered for the resource
       assertResourceRegistered({ span, url, startTime, endTime });
@@ -430,9 +430,31 @@ describe('FetchInstrumentation', () => {
       expect(span.attributes[ATTR_URL_FULL]).toEqual(url);
       expect(span.attributes[ATTR_SERVER_ADDRESS]).toEqual(VITEST_SERVER_NAME);
       expect(span.attributes[ATTR_SERVER_PORT]).toEqual(VITEST_SERVER_PORT);
-      expect(span.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE]).toEqual(0);
+      expect(span.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE]).toBeUndefined();
       expect(span.status.code).toEqual(SpanStatusCode.ERROR);
-      expect(span.attributes[ATTR_ERROR_TYPE]).toEqual('Failed to fetch');
+      expect(span.attributes[ATTR_ERROR_TYPE]).toEqual('TypeError');
+
+      // Context has been registered for the resource
+      assertResourceRegistered({ span, url, startTime, endTime });
+    });
+
+    it('should not record an error when the request is intentionally aborted', async () => {
+      const url = getUrlForPath('/api/get');
+      const startTime = performance.now();
+      const controller = new AbortController();
+      const fetchPromise = fetch(url, { signal: controller.signal });
+      controller.abort();
+      await expect(fetchPromise).rejects.toThrow();
+      const endTime = performance.now();
+
+      // Span is exported
+      const span = await waitForSpan(url);
+      expect(span.name).toBe('GET');
+      expect(span.kind).toEqual(SpanKind.CLIENT);
+      expect(span.attributes[ATTR_URL_FULL]).toEqual(url);
+      expect(span.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE]).toBeUndefined();
+      expect(span.attributes[ATTR_ERROR_TYPE]).toBeUndefined();
+      expect(span.status.code).toEqual(SpanStatusCode.UNSET);
 
       // Context has been registered for the resource
       assertResourceRegistered({ span, url, startTime, endTime });

--- a/packages/instrumentation/src/fetch/instrumentation.ts
+++ b/packages/instrumentation/src/fetch/instrumentation.ts
@@ -167,8 +167,9 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
           function endSpanOnError(span: Span, error: FetchError) {
             instrumentation._applyAttributesAfterFetch(span, options, error);
             instrumentation._endSpan(span, {
-              statusText: error.name || error.message,
-              aborted: options.signal?.aborted ?? false,
+              status: error.status,
+              error: error.name || error.message,
+              aborted: error.name === 'AbortError',
             });
           }
 
@@ -207,11 +208,27 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
                           'Failed to finalize span after body read',
                           e,
                         );
-                        instrumentation._endSpan(span, {});
+                        instrumentation._endSpan(span, {
+                          status: response.status,
+                        });
                       }
                     },
                     (error) => {
-                      endSpanOnError(span, error);
+                      try {
+                        endSpanOnError(span, {
+                          name: error?.name,
+                          message: error?.message,
+                          status: response.status,
+                        });
+                      } catch (e) {
+                        instrumentation._diag.error(
+                          'Failed to end span after body read rejected',
+                          e,
+                        );
+                        instrumentation._endSpan(span, {
+                          status: response.status,
+                        });
+                      }
                     },
                   );
                 };
@@ -221,12 +238,11 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
                 endSpanOnSuccess(span, response);
               }
             } catch (error) {
-              // Setup failed (e.g. clone() or getReader() threw).
               instrumentation._diag.error(
                 'Failed to read fetch response body',
                 error,
               );
-              instrumentation._endSpan(span, {});
+              instrumentation._endSpan(span, { status: response.status });
             }
             return response;
           }
@@ -321,25 +337,24 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
     }
 
     // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status
-    // 1xx/2xx/3xx MUST be left unset; only a missing response (no status) or
-    // 4xx/5xx count as an error here.
+    // 1xx/2xx/3xx MUST be left unset UNLESS there was another error (e.g. a
+    // network error receiving the response body)
     if (!response.aborted) {
       const isErrorStatus =
-        response.status === undefined || response.status >= 400;
+        response.status === undefined ||
+        response.status >= 400 ||
+        response.error !== undefined;
       if (isErrorStatus) {
         span.setStatus({ code: SpanStatusCode.ERROR });
-        // Prefer the numeric status code (as a string) when a response was
-        // received; otherwise this carries the caller-supplied error identifier
-        // (see endSpanOnError, which favors the exception's `name`).
         const errorType =
-          response.status !== undefined
-            ? String(response.status)
-            : response.statusText;
+          response.error ??
+          (response.status !== undefined ? String(response.status) : undefined);
         if (typeof errorType === 'string') {
           span.setAttribute(ATTR_ERROR_TYPE, errorType);
         }
       }
     }
+
     span.end();
 
     // Register the resource context for other instrumentations

--- a/packages/instrumentation/src/fetch/instrumentation.ts
+++ b/packages/instrumentation/src/fetch/instrumentation.ts
@@ -167,8 +167,8 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
           function endSpanOnError(span: Span, error: FetchError) {
             instrumentation._applyAttributesAfterFetch(span, options, error);
             instrumentation._endSpan(span, {
-              status: error.status || 0,
-              statusText: error.message,
+              statusText: error.name || error.message,
+              aborted: options.signal?.aborted ?? false,
             });
           }
 
@@ -207,7 +207,7 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
                           'Failed to finalize span after body read',
                           e,
                         );
-                        instrumentation._endSpan(span, { status: 0 });
+                        instrumentation._endSpan(span, {});
                       }
                     },
                     (error) => {
@@ -226,9 +226,7 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
                 'Failed to read fetch response body',
                 error,
               );
-              instrumentation._endSpan(span, {
-                status: 0,
-              });
+              instrumentation._endSpan(span, {});
             }
             return response;
           }
@@ -237,14 +235,13 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
             try {
               endSpanOnError(span, error);
             } catch (e: unknown) {
-              // endSpanOnError failed — fall back to ending the span directly
+              // endSpanOnError failed — fall back to ending the span directly.
+              // No `status`: no response was ever received for this request.
               instrumentation._diag.error(
                 'Failed to end span on fetch error',
                 e,
               );
-              instrumentation._endSpan(span, {
-                status: error.status || 0,
-              });
+              instrumentation._endSpan(span, {});
             }
             throw error;
           }
@@ -319,14 +316,28 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
    * Finish span, add attributes, etc.
    */
   private _endSpan(span: Span, response: FetchResponse) {
-    span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, response.status);
+    if (response.status !== undefined) {
+      span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, response.status);
+    }
 
     // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status
-    const isErrorStatus = response.status < 200 || response.status >= 400;
-    if (isErrorStatus) {
-      span.setStatus({ code: SpanStatusCode.ERROR });
-      if (typeof response.statusText === 'string') {
-        span.setAttribute(ATTR_ERROR_TYPE, response.statusText);
+    // 1xx/2xx/3xx MUST be left unset; only a missing response (no status) or
+    // 4xx/5xx count as an error here.
+    if (!response.aborted) {
+      const isErrorStatus =
+        response.status === undefined || response.status >= 400;
+      if (isErrorStatus) {
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        // Prefer the numeric status code (as a string) when a response was
+        // received; otherwise this carries the caller-supplied error identifier
+        // (see endSpanOnError, which favors the exception's `name`).
+        const errorType =
+          response.status !== undefined
+            ? String(response.status)
+            : response.statusText;
+        if (typeof errorType === 'string') {
+          span.setAttribute(ATTR_ERROR_TYPE, errorType);
+        }
       }
     }
     span.end();

--- a/packages/instrumentation/src/fetch/types.ts
+++ b/packages/instrumentation/src/fetch/types.ts
@@ -7,19 +7,25 @@ import type { Span } from '@opentelemetry/api';
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
 /**
- * Interface used to provide information to finish span on fetch response
+ * Interface used to provide information to finish span on fetch response.
+ * `status` is omitted when no HTTP response was ever received (e.g. a
+ * network error), per
+ * https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status
  */
 export interface FetchResponse {
-  status: number;
+  status?: number;
   statusText?: string;
+  /** Whether the request was intentionally cancelled by the caller (e.g. via AbortController). */
+  aborted?: boolean;
 }
 
 /**
  * Interface used to provide information to finish span on fetch error
  */
 export interface FetchError {
-  status?: number;
   message: string;
+  /** The error's exception type (e.g. `TypeError`, `AbortError`), if available. */
+  name?: string;
 }
 
 export type FetchCustomAttributeFunction = (

--- a/packages/instrumentation/src/fetch/types.ts
+++ b/packages/instrumentation/src/fetch/types.ts
@@ -14,7 +14,12 @@ import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
  */
 export interface FetchResponse {
   status?: number;
-  statusText?: string;
+  /**
+   * Error identifier used as `error.type` (e.g. the exception's `name`).
+   * Not the HTTP status reason phrase. Also forces the span into an error
+   * state even if `status` is a non-error code.
+   */
+  error?: string;
   /** Whether the request was intentionally cancelled by the caller (e.g. via AbortController). */
   aborted?: boolean;
 }
@@ -23,6 +28,7 @@ export interface FetchResponse {
  * Interface used to provide information to finish span on fetch error
  */
 export interface FetchError {
+  status?: number;
   message: string;
   /** The error's exception type (e.g. `TypeError`, `AbortError`), if available. */
   name?: string;


### PR DESCRIPTION
## Summary
- Add e2e tests for `FetchInstrumentation`: span creation, non-2xx responses, network errors, aborts, parent/child context, and correlation with `ResourceTimingInstrumentation`
- Found and fixed three discrepancies of the [HTTP span status semantic convention](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status) in `FetchInstrumentation`:
  - Intentional request cancellation (`AbortController`) was treated as an error instead of leaving the span status unset with no `error.type`.
  - `http.response.status_code` was set to `0` for network errors/aborts instead of being omitted (no response was ever received).
  - `error.type` used the HTTP status reason phrase (e.g. `"Internal Server Error"`) instead of the numeric status code as a string (e.g. `"500"`), and the exception's `message` instead of its `name` for pre-response errors.