### PR TITLE
feat(sdk): wire default context manager and propagators into startTracesSdk

### DIFF
--- a/packages/sdk/src/traces/startTracesSdk.test.ts
+++ b/packages/sdk/src/traces/startTracesSdk.test.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { diag, trace } from '@opentelemetry/api';
+import type { ContextManager, TextMapPropagator } from '@opentelemetry/api';
+import {
+  context,
+  diag,
+  propagation,
+  ROOT_CONTEXT,
+  trace,
+} from '@opentelemetry/api';
 import {
   AlwaysOffSampler,
   SimpleSpanProcessor,
@@ -31,6 +38,8 @@ describe('startTracesSdk', () => {
     fetchSpy.mockClear();
     await tracesSdk?.shutdown();
     trace.disable();
+    context.disable();
+    propagation.disable();
   });
 
   it('should not start if disabled by configuration', async () => {
@@ -266,5 +275,41 @@ describe('startTracesSdk', () => {
 
     // Assert
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should install default context manager and propagators when none are provided', () => {
+    tracesSdk = startTracesSdk({
+      batchProcessorConfig: { scheduledDelayMillis: BSP_SCHEDULE_DELAY },
+    });
+
+    expect(context.active()).toBe(ROOT_CONTEXT);
+    expect(propagation.fields()).toEqual(
+      expect.arrayContaining(['traceparent', 'tracestate', 'baggage']),
+    );
+  });
+
+  it('should use the provided context manager and propagators', () => {
+    const enableSpy = vi.fn().mockReturnThis();
+    const customContextManager: ContextManager = {
+      active: () => ROOT_CONTEXT,
+      with: (_ctx, fn, thisArg, ...args) => fn.call(thisArg, ...args),
+      bind: (_ctx, target) => target,
+      enable: enableSpy,
+      disable: vi.fn().mockReturnThis(),
+    };
+    const customPropagator: TextMapPropagator = {
+      inject: vi.fn(),
+      extract: (_ctx, _carrier, _getter) => _ctx,
+      fields: () => ['x-custom-trace'],
+    };
+
+    tracesSdk = startTracesSdk({
+      batchProcessorConfig: { scheduledDelayMillis: BSP_SCHEDULE_DELAY },
+      contextManager: customContextManager,
+      propagators: [customPropagator],
+    });
+
+    expect(enableSpy).toHaveBeenCalledOnce();
+    expect(propagation.fields()).toEqual(['x-custom-trace']);
   });
 });

--- a/packages/sdk/src/traces/startTracesSdk.ts
+++ b/packages/sdk/src/traces/startTracesSdk.ts
@@ -12,7 +12,9 @@ import {
 } from '@opentelemetry/resources';
 import type { SpanProcessor } from '@opentelemetry/sdk-trace';
 import { BatchSpanProcessor, TracerProvider } from '@opentelemetry/sdk-trace';
+import { getDefaultContextManager } from '../core/context.ts';
 import { setSdkLogger } from '../core/diag.ts';
+import { getDefaultPropagators } from '../core/propagation.ts';
 import type { TracesConfig, WebSdk } from '../core/types.ts';
 
 const DEFAULT_TRACES_OTLP_ENDPOINT = 'http://localhost:4318/v1/traces';
@@ -82,14 +84,12 @@ export function startTracesSdk(config?: TracesConfig): WebSdk {
   });
   trace.setGlobalTracerProvider(tracerProvider);
 
-  if (config?.propagators) {
-    const { propagators } = config;
-    propagation.setGlobalPropagator(new CompositePropagator({ propagators }));
-  }
+  const propagators = config?.propagators ?? getDefaultPropagators();
+  propagation.setGlobalPropagator(new CompositePropagator({ propagators }));
 
-  if (config?.contextManager) {
-    context.setGlobalContextManager(config.contextManager);
-  }
+  const contextManager = config?.contextManager ?? getDefaultContextManager();
+  contextManager.enable();
+  context.setGlobalContextManager(contextManager);
 
   return {
     shutdown() {


### PR DESCRIPTION
Fixes #390

## Summary

`startTracesSdk` was only installing a context manager and propagators when the user explicitly passed them in config. Calling `startTracesSdk({})` with default config left no global context manager or propagator registered, silently breaking trace context propagation and W3C header injection.

This PR wires the existing defaults into SDK startup by following the proposed behavior (quoting the issue):

- If config.contextManager is provided, install that.
- Otherwise install the default browser context manager.
- If config.propagators is provided, install a CompositePropagator using those propagators.
- Otherwise install a CompositePropagator using getDefaultPropagators().
- Call contextManager.enable() before registering it.
- Add tests covering default registration and user overrides:
    - Added a test verifying default registration when no config is provided
    - Added a test verifying user-provided context manager and propagators take precedence
    - `afterEach` now cleans up `context` and `propagation` global state to prevent test cross-contamination