### PR TITLE
feat(instrumentation): add long-task logs

### DIFF
--- a/packages/instrumentation/README.md
+++ b/packages/instrumentation/README.md
@@ -20,6 +20,7 @@ npm install @opentelemetry/browser-instrumentation
 - [Web Vitals](#web-vitals) — automatic instrumentation for Core Web Vitals
 - [Console](#console) — automatic instrumentation for console API calls (log, warn, error, info, debug)
 - [Errors](#errors) — automatic instrumentation for unhandled errors and promise rejections
+- [Long Task](#long-task) — automatic instrumentation for tasks that block the main thread
 - [Fetch](#fetch) — automatic instrumentation for request using the `fetch` API
 
 ## Usage
@@ -33,6 +34,7 @@ import {
 } from '@opentelemetry/sdk-logs';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { ErrorsInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/errors';
+import { LongTaskInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/long-task';
 import { NavigationInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/navigation';
 import { NavigationTimingInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/navigation-timing';
 import { ResourceTimingInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/resource-timing';
@@ -49,6 +51,7 @@ logs.setGlobalLoggerProvider(logProvider);
 registerInstrumentations({
   instrumentations: [
     new ErrorsInstrumentation(),
+    new LongTaskInstrumentation(),
     new NavigationInstrumentation(),
     new NavigationTimingInstrumentation(),
     new ResourceTimingInstrumentation(),
@@ -57,6 +60,49 @@ registerInstrumentations({
   ],
 });
 ```
+
+---
+
+### Long Task
+
+```typescript
+import { LongTaskInstrumentation } from '@opentelemetry/browser-instrumentation/experimental/long-task';
+```
+
+Emits a `browser.long_task` log for every task reported by the browser's [Long Tasks API](https://developer.mozilla.org/en-US/docs/Web/API/Long_Tasks_API). Long tasks block the main thread for 50 milliseconds or more and can make an application feel unresponsive.
+
+> [!NOTE]
+> The Long Tasks API is not available in every browser. The instrumentation remains inactive when the browser does not report `longtask` support through `PerformanceObserver`.
+
+#### Configuration
+
+```typescript
+new LongTaskInstrumentation({
+  applyCustomLogRecordData: (logRecord) => {
+    logRecord.attributes = {
+      ...logRecord.attributes,
+      'app.route.id': 'checkout',
+    };
+  },
+});
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `applyCustomLogRecordData` | `(logRecord: LogRecord) => void` | — | Hook to modify log records before they are emitted. Errors thrown from this hook are caught and logged via the instrumentation diag logger. |
+
+#### Captured Attributes
+
+Each `browser.long_task` event includes:
+
+| Attribute | Description |
+|-----------|-------------|
+| `browser.long_task.name` | The name reported by the performance entry (for example, `self`). |
+| `browser.long_task.entry_type` | The performance entry type (`longtask`). |
+| `browser.long_task.duration` | Duration of the task in milliseconds. |
+| `browser.long_task.attribution` | Structured task-attribution entries, including container type, source, ID, and name when the browser provides them. |
+
+The log timestamp is the task's start time converted from the performance timeline to Unix epoch time.
 
 ---
 

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -32,6 +32,7 @@
   "exports": {
     "./experimental/console": "./dist/console/index.js",
     "./experimental/errors": "./dist/errors/index.js",
+    "./experimental/long-task": "./dist/long-task/index.js",
     "./experimental/navigation": "./dist/navigation/index.js",
     "./experimental/navigation-timing": "./dist/navigation-timing/index.js",
     "./experimental/resource-timing": "./dist/resource-timing/index.js",

--- a/packages/instrumentation/src/long-task/index.ts
+++ b/packages/instrumentation/src/long-task/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { LongTaskInstrumentation } from './instrumentation.ts';
+export type {
+  LongTaskInstrumentationConfig,
+  PerformanceLongTaskTiming,
+  TaskAttributionTiming,
+} from './types.ts';

--- a/packages/instrumentation/src/long-task/instrumentation.test.ts
+++ b/packages/instrumentation/src/long-task/instrumentation.test.ts
@@ -1,0 +1,282 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { hrTimeToMilliseconds } from '@opentelemetry/core';
+import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { setupTestLogExporter } from '#utils/test';
+import { LongTaskInstrumentation } from './instrumentation.ts';
+import {
+  ATTR_LONG_TASK_ATTRIBUTION,
+  ATTR_LONG_TASK_DURATION,
+  ATTR_LONG_TASK_ENTRY_TYPE,
+  ATTR_LONG_TASK_NAME,
+  LONG_TASK_EVENT_NAME,
+} from './semconv.ts';
+import type { PerformanceLongTaskTiming } from './types.ts';
+
+describe('LongTaskInstrumentation', () => {
+  let inMemoryExporter: InMemoryLogRecordExporter;
+  let instrumentation: LongTaskInstrumentation;
+  let observerCallback: PerformanceObserverCallback;
+  let observe: ReturnType<typeof vi.fn>;
+  let disconnect: ReturnType<typeof vi.fn>;
+  let PerformanceObserverMock: ReturnType<typeof vi.fn>;
+
+  beforeAll(() => {
+    inMemoryExporter = setupTestLogExporter();
+  });
+
+  beforeEach(() => {
+    observe = vi.fn();
+    disconnect = vi.fn();
+    PerformanceObserverMock = vi.fn(function (
+      this: unknown,
+      callback: PerformanceObserverCallback,
+    ) {
+      observerCallback = callback;
+      return { observe, disconnect };
+    });
+    Object.defineProperty(PerformanceObserverMock, 'supportedEntryTypes', {
+      configurable: true,
+      value: ['longtask'],
+    });
+    vi.stubGlobal('PerformanceObserver', PerformanceObserverMock);
+  });
+
+  afterEach(() => {
+    instrumentation?.disable();
+    inMemoryExporter.reset();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('observes buffered long-task entries and emits their attributes as logs', () => {
+    instrumentation = new LongTaskInstrumentation();
+
+    expect(observe).toHaveBeenCalledWith({ type: 'longtask', buffered: true });
+
+    const entry = createLongTaskEntry();
+    observerCallback(createEntryList([entry]), {
+      disconnect,
+    } as unknown as PerformanceObserver);
+
+    const records = inMemoryExporter.getFinishedLogRecords();
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      eventName: LONG_TASK_EVENT_NAME,
+      attributes: {
+        [ATTR_LONG_TASK_NAME]: 'self',
+        [ATTR_LONG_TASK_ENTRY_TYPE]: 'longtask',
+        [ATTR_LONG_TASK_DURATION]: 73,
+        [ATTR_LONG_TASK_ATTRIBUTION]: [
+          {
+            name: 'script',
+            entry_type: 'taskattribution',
+            start_time: 12,
+            duration: 73,
+            container_type: 'window',
+            container_src: 'https://example.com/app.js',
+            container_id: 'app',
+            container_name: 'main',
+          },
+        ],
+      },
+    });
+  });
+
+  it('uses the entry start time as the log timestamp', () => {
+    instrumentation = new LongTaskInstrumentation();
+    const entry = createLongTaskEntry({ startTime: 456 });
+
+    observerCallback(createEntryList([entry]), {
+      disconnect,
+    } as unknown as PerformanceObserver);
+
+    const [record] = inMemoryExporter.getFinishedLogRecords();
+    expect(record).toBeDefined();
+    if (!record) {
+      return;
+    }
+    expect(hrTimeToMilliseconds(record.hrTime)).toBe(
+      performance.timeOrigin + 456,
+    );
+  });
+
+  it('allows custom log record data and contains hook errors', () => {
+    const hook = vi
+      .fn()
+      .mockImplementationOnce((record) => {
+        record.attributes = {
+          ...record.attributes,
+          'app.route': '/checkout',
+        };
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('hook failed');
+      });
+    instrumentation = new LongTaskInstrumentation({
+      applyCustomLogRecordData: hook,
+    });
+    const diagError = vi
+      .spyOn(
+        (
+          instrumentation as unknown as {
+            _diag: { error: (...args: unknown[]) => void };
+          }
+        )._diag,
+        'error',
+      )
+      .mockImplementation(() => {});
+
+    observerCallback(
+      createEntryList([
+        createLongTaskEntry(),
+        createLongTaskEntry({ startTime: 200 }),
+      ]),
+      { disconnect } as unknown as PerformanceObserver,
+    );
+
+    const records = inMemoryExporter.getFinishedLogRecords();
+    expect(records).toHaveLength(2);
+    expect(records[0]?.attributes['app.route']).toBe('/checkout');
+    expect(diagError).toHaveBeenCalledWith(
+      'applyCustomLogRecordData hook failed',
+      expect.any(Error),
+    );
+  });
+
+  it('does not create an observer when PerformanceObserver is unavailable', () => {
+    vi.stubGlobal('PerformanceObserver', undefined);
+
+    instrumentation = new LongTaskInstrumentation();
+
+    expect(PerformanceObserverMock).not.toHaveBeenCalled();
+  });
+
+  it('does not create an observer when supported entry types are unavailable', () => {
+    Object.defineProperty(PerformanceObserverMock, 'supportedEntryTypes', {
+      configurable: true,
+      value: undefined,
+    });
+
+    instrumentation = new LongTaskInstrumentation();
+
+    expect(PerformanceObserverMock).not.toHaveBeenCalled();
+  });
+
+  it('does not create an observer when long tasks are unsupported', () => {
+    Object.defineProperty(PerformanceObserverMock, 'supportedEntryTypes', {
+      configurable: true,
+      value: ['resource'],
+    });
+
+    instrumentation = new LongTaskInstrumentation();
+
+    expect(PerformanceObserverMock).not.toHaveBeenCalled();
+  });
+
+  it('disconnects the observer and can be enabled again', () => {
+    instrumentation = new LongTaskInstrumentation();
+
+    instrumentation.disable();
+    instrumentation.disable();
+    instrumentation.enable();
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(PerformanceObserverMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not emit a queued callback after being disabled', () => {
+    instrumentation = new LongTaskInstrumentation();
+    instrumentation.disable();
+
+    observerCallback(createEntryList([createLongTaskEntry()]), {
+      disconnect,
+    } as unknown as PerformanceObserver);
+
+    expect(inMemoryExporter.getFinishedLogRecords()).toHaveLength(0);
+  });
+
+  it('omits attribution when the browser does not provide an array', () => {
+    instrumentation = new LongTaskInstrumentation();
+    const entry = createLongTaskEntry();
+    Object.defineProperty(entry, 'attribution', { value: undefined });
+
+    observerCallback(createEntryList([entry]), {
+      disconnect,
+    } as unknown as PerformanceObserver);
+
+    const [record] = inMemoryExporter.getFinishedLogRecords();
+    expect(record?.attributes).not.toHaveProperty(ATTR_LONG_TASK_ATTRIBUTION);
+  });
+
+  it('contains observer setup failures', () => {
+    observe.mockImplementation(() => {
+      throw new Error('observe failed');
+    });
+    instrumentation = new LongTaskInstrumentation({ enabled: false });
+    const diagError = vi
+      .spyOn(
+        (
+          instrumentation as unknown as {
+            _diag: { error: (...args: unknown[]) => void };
+          }
+        )._diag,
+        'error',
+      )
+      .mockImplementation(() => {});
+
+    expect(() => instrumentation.enable()).not.toThrow();
+    expect(diagError).toHaveBeenCalledWith(
+      'Failed to start long-task PerformanceObserver',
+      expect.any(Error),
+    );
+  });
+});
+
+function createEntryList(
+  entries: PerformanceLongTaskTiming[],
+): PerformanceObserverEntryList {
+  return {
+    getEntries: () => entries,
+    getEntriesByName: () => entries,
+    getEntriesByType: () => entries,
+  } as PerformanceObserverEntryList;
+}
+
+function createLongTaskEntry(
+  overrides: Partial<PerformanceLongTaskTiming> = {},
+): PerformanceLongTaskTiming {
+  return {
+    name: 'self',
+    entryType: 'longtask',
+    startTime: 100,
+    duration: 73,
+    attribution: [
+      {
+        name: 'script',
+        entryType: 'taskattribution',
+        startTime: 12,
+        duration: 73,
+        containerType: 'window',
+        containerSrc: 'https://example.com/app.js',
+        containerId: 'app',
+        containerName: 'main',
+        toJSON: () => ({}),
+      },
+    ],
+    toJSON: () => ({}),
+    ...overrides,
+  };
+}

--- a/packages/instrumentation/src/long-task/instrumentation.ts
+++ b/packages/instrumentation/src/long-task/instrumentation.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The Long Tasks API is not Baseline and is currently unavailable in Safari.
+// https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming
+/* eslint-disable baseline-js/use-baseline */
+
+import type { AnyValueMap, LogRecord } from '@opentelemetry/api-logs';
+import { SeverityNumber } from '@opentelemetry/api-logs';
+import {
+  InstrumentationBase,
+  safeExecuteInTheMiddle,
+} from '@opentelemetry/instrumentation';
+import { version } from '../../package.json' with { type: 'json' };
+import {
+  ATTR_LONG_TASK_ATTRIBUTION,
+  ATTR_LONG_TASK_DURATION,
+  ATTR_LONG_TASK_ENTRY_TYPE,
+  ATTR_LONG_TASK_NAME,
+  LONG_TASK_EVENT_NAME,
+} from './semconv.ts';
+import type {
+  LongTaskInstrumentationConfig,
+  PerformanceLongTaskTiming,
+} from './types.ts';
+
+const LONG_TASK_ENTRY_TYPE = 'longtask';
+
+/** Captures Long Tasks API performance entries as OpenTelemetry logs. */
+export class LongTaskInstrumentation extends InstrumentationBase<LongTaskInstrumentationConfig> {
+  private declare _isEnabled: boolean;
+  private declare _observer?: PerformanceObserver;
+
+  constructor(config: LongTaskInstrumentationConfig = {}) {
+    super('@opentelemetry/browser-instrumentation/long-task', version, config);
+  }
+
+  protected override init() {
+    return [];
+  }
+
+  override enable(): void {
+    if (this._observer || !this._isSupported()) {
+      return;
+    }
+
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        this._emitLongTask(entry as PerformanceLongTaskTiming);
+      }
+    });
+
+    try {
+      observer.observe({ type: LONG_TASK_ENTRY_TYPE, buffered: true });
+      this._observer = observer;
+      this._isEnabled = true;
+    } catch (error) {
+      observer.disconnect();
+      this._diag.error('Failed to start long-task PerformanceObserver', error);
+    }
+  }
+
+  override disable(): void {
+    this._isEnabled = false;
+    this._observer?.disconnect();
+    this._observer = undefined;
+  }
+
+  private _isSupported(): boolean {
+    if (
+      typeof PerformanceObserver === 'undefined' ||
+      !PerformanceObserver.supportedEntryTypes
+    ) {
+      this._diag.debug(
+        'PerformanceObserver is not supported, long tasks will not be collected',
+      );
+      return false;
+    }
+
+    const supported =
+      PerformanceObserver.supportedEntryTypes.includes(LONG_TASK_ENTRY_TYPE);
+    if (!supported) {
+      this._diag.debug(
+        'Long Tasks API is not supported, long tasks will not be collected',
+      );
+    }
+    return supported;
+  }
+
+  private _emitLongTask(entry: PerformanceLongTaskTiming): void {
+    if (!this._isEnabled) {
+      return;
+    }
+
+    const record: LogRecord = {
+      eventName: LONG_TASK_EVENT_NAME,
+      severityNumber: SeverityNumber.INFO,
+      timestamp: performance.timeOrigin + entry.startTime,
+      attributes: {
+        [ATTR_LONG_TASK_NAME]: entry.name,
+        [ATTR_LONG_TASK_ENTRY_TYPE]: entry.entryType,
+        [ATTR_LONG_TASK_DURATION]: entry.duration,
+        ...(Array.isArray(entry.attribution) && entry.attribution.length > 0
+          ? {
+              [ATTR_LONG_TASK_ATTRIBUTION]: entry.attribution.map(
+                (attribution): AnyValueMap => ({
+                  name: attribution.name,
+                  entry_type: attribution.entryType,
+                  start_time: attribution.startTime,
+                  duration: attribution.duration,
+                  container_type: attribution.containerType,
+                  container_src: attribution.containerSrc,
+                  container_id: attribution.containerId,
+                  container_name: attribution.containerName,
+                }),
+              ),
+            }
+          : {}),
+      },
+    };
+
+    const hook = this.getConfig().applyCustomLogRecordData;
+    if (hook) {
+      safeExecuteInTheMiddle(
+        () => hook(record),
+        (error) => {
+          if (error) {
+            this._diag.error('applyCustomLogRecordData hook failed', error);
+          }
+        },
+        true,
+      );
+    }
+
+    safeExecuteInTheMiddle(
+      () => this.logger.emit(record),
+      (error) => {
+        if (error) {
+          this._diag.error('Failed to emit long-task log record', error);
+        }
+      },
+      true,
+    );
+  }
+}

--- a/packages/instrumentation/src/long-task/semconv.ts
+++ b/packages/instrumentation/src/long-task/semconv.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Event name for Long Tasks API entries. */
+export const LONG_TASK_EVENT_NAME = 'browser.long_task';
+
+/** Name reported by the long-task performance entry. */
+export const ATTR_LONG_TASK_NAME = 'browser.long_task.name';
+
+/** Performance entry type, normally `longtask`. */
+export const ATTR_LONG_TASK_ENTRY_TYPE = 'browser.long_task.entry_type';
+
+/** Total duration of the task in milliseconds. */
+export const ATTR_LONG_TASK_DURATION = 'browser.long_task.duration';
+
+/** Structured attribution entries reported for the task. */
+export const ATTR_LONG_TASK_ATTRIBUTION = 'browser.long_task.attribution';

--- a/packages/instrumentation/src/long-task/types.ts
+++ b/packages/instrumentation/src/long-task/types.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { LogRecord } from '@opentelemetry/api-logs';
+import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
+
+/** A task-attribution entry reported by the Long Tasks API. */
+export interface TaskAttributionTiming extends PerformanceEntry {
+  containerType: string;
+  containerSrc: string;
+  containerId: string;
+  containerName: string;
+}
+
+/** A long-task performance entry, currently missing from TypeScript DOM types. */
+export interface PerformanceLongTaskTiming extends PerformanceEntry {
+  attribution: TaskAttributionTiming[];
+}
+
+export type ApplyCustomLogRecordDataFunction = (logRecord: LogRecord) => void;
+
+/** LongTaskInstrumentation configuration. */
+export interface LongTaskInstrumentationConfig extends InstrumentationConfig {
+  /** Hook to modify long-task log records before they are emitted. */
+  applyCustomLogRecordData?: ApplyCustomLogRecordDataFunction;
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Moves long-task instrumentation into the consolidated browser instrumentation package, as requested in #381. The existing contrib instrumentation models long tasks as spans; this implementation uses OpenTelemetry log events so browser performance entries remain events rather than synthetic operations.

Fixes #381

## Short description of the changes

- adds an experimental `LongTaskInstrumentation` export
- observes buffered `longtask` performance entries when the browser supports the Long Tasks API
- emits one `browser.long_task` log event per entry with duration, entry metadata, and structured task attribution
- preserves the performance-entry start time as the log timestamp
- supports an `applyCustomLogRecordData` hook while containing hook/exporter failures
- handles unsupported browsers and observer lifecycle safely
- documents setup, configuration, captured attributes, and browser-support behavior

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Tested locally with the repository's required Node.js 24 toolchain:

- [x] `npm run lint:ci`
- [x] `npm test` — all package tests passed; the instrumentation package ran 282 tests across 18 files
- [x] `npm run validate`
- [x] `npm run build --workspace @opentelemetry/browser-instrumentation`
- [x] `npm run check-types --workspace @opentelemetry/browser-instrumentation`
- [x] `npm test --workspace @opentelemetry/browser-instrumentation`

The new long-task suite has 10 tests covering log attributes, timestamps, customization hooks, unsupported environments, lifecycle behavior, delayed callbacks after disable, missing attribution, and observer setup failures. I also verified the behavioral test fails when the observer setup is intentionally disabled, then passes again with the implementation restored.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
