### PR TITLE
chore: add semantic convention registry

### DIFF
--- a/docs/browser-observability-model.md
+++ b/docs/browser-observability-model.md
@@ -25,6 +25,8 @@ All events listed below are implemented in this repository's [`@opentelemetry/br
 
 In the [semantic-conventions](https://github.com/open-telemetry/semantic-conventions) repository, only `browser.web_vital` (development stability) and `exception` (stable) are currently defined. The earlier PRs proposing conventions for the remaining browser events were closed as stale; the attributes emitted by the instrumentations in this repository serve as the working definitions in the meantime. Longer term, a federated semantic conventions repository for end-user client applications is being discussed ([community #3594](https://github.com/open-telemetry/community/issues/3594)). Conventions shared across client platforms may move to that repository, while browser-specific conventions might remain in this repository.
 
+The attributes of these events are defined as a machine-readable semantic convention registry under [`semconv/`](https://github.com/open-telemetry/opentelemetry-browser/tree/main/semconv), which this document intentionally does not enumerate.
+
 ---
 
 ## Browser Events

--- a/semconv/README.md
+++ b/semconv/README.md
@@ -1,22 +1,11 @@
 # Federated Browser Semantic Conventions
 
-This directory holds the semantic conventions that the packages in this repository emit, modelled
-as a federated semantic convention registry ([OTEP 4815](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/4815-semantic-conventions-schema-v2.md)).
-The registry manifest declares the upstream
-[OpenTelemetry semantic conventions](https://github.com/open-telemetry/semantic-conventions) as an
-exact-version dependency, so our events can reference upstream attributes without redefining them.
-
-The same approach is used by
-[opentelemetry-android](https://github.com/open-telemetry/opentelemetry-android/tree/main/semconv).
+This directory holds the semantic conventions that the packages in this repository emit, modelled as a federated semantic convention registry. The registry manifest declares the upstream [OpenTelemetry semantic conventions](https://github.com/open-telemetry/semantic-conventions) as an exact-version dependency, so our events can reference upstream attributes without redefining them.
 
 ## Why these live here
 
-The semantic-conventions
-[CONTRIBUTING guide](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md)
-places conventions specific to a single runtime or a narrowly scoped implementation in the
-corresponding repository, and most of the conventions below are browser-only. Defining them here
-also gives a concrete starting point for the client-side registry proposed in
-[community#3594](https://github.com/open-telemetry/community/issues/3594).
+The semantic-conventions [CONTRIBUTING guide](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) places conventions specific to a single runtime or a narrowly scoped implementation in the
+corresponding repository, and most of the conventions below are browser-only.
 
 Names already covered upstream are deliberately not redefined. The `browser.web_vital` and
 `exception` events are imported from the dependency registry by name, and the `error.*`, `http.*`,
@@ -36,25 +25,11 @@ model/
 
 ## Checking the registry
 
-Weaver is not required to install, build, or check the packages in this repository. To validate the
-model, run the [`weaver`](https://github.com/open-telemetry/weaver) CLI over `model/`:
+Weaver is not required to install, build, or check the packages in this repository. To validate the model, run the [`weaver`](https://github.com/open-telemetry/weaver) CLI over `model/`:
 
 ```bash
 docker run --rm -v "$PWD/semconv/model:/home/weaver/model" \
   otel/weaver:v0.25.1 registry check -r /home/weaver/model
 ```
 
-This resolves every `ref` against the pinned upstream version, so it catches unknown attribute
-references, malformed enum members, and duplicate ids.
-
-Do not pass `--future`: at the pinned upstream version it promotes the upstream registry's own
-`definition/2` file-format warnings to errors, which says nothing about this model.
-
-## Status
-
-The model currently describes what the instrumentations emit today, with no new conventions and no
-renames. Generating the TypeScript attribute and event-name constants from it, and enforcing the
-model in CI, are tracked in
-[#403](https://github.com/open-telemetry/opentelemetry-browser/issues/403). Until then the
-constants in the `semconv.ts` files under `packages/` remain hand-written, and changing an
-attribute means changing both.
+This resolves every `ref` against the pinned upstream version, so it catches unknown attribute references, malformed enum members, and duplicate ids.

--- a/semconv/README.md
+++ b/semconv/README.md
@@ -8,8 +8,15 @@ The semantic-conventions [CONTRIBUTING guide](https://github.com/open-telemetry/
 corresponding repository, and most of the conventions below are browser-only.
 
 Names already covered upstream are deliberately not redefined. The `browser.web_vital` and
-`exception` events are imported from the dependency registry by name, and the `error.*`, `http.*`,
-`server.*`, `session.*`, and `url.*` attributes we emit are referenced from it.
+`exception` events are imported from the dependency registry by name, and the `http.request.body.size`,
+`session.id`, and `url.full` attributes we emit are referenced from it.
+
+Upstream conventions that are already stable are not modelled here at all. Their constants ship in
+the root export of [`@opentelemetry/semantic-conventions`](https://www.npmjs.com/package/@opentelemetry/semantic-conventions),
+so the instrumentations import them directly and this registry has nothing to add. What it does
+cover is the attributes we emit that upstream has not stabilised, which the package exports only
+from its `/incubating` entry point — today `http.request.body.size` on the fetch and XHR spans,
+and `session.id` on everything the SDK emits.
 
 ## Layout
 
@@ -19,7 +26,7 @@ model/
 └── browser/
     ├── registry.yaml      # attributes defined by this repository
     ├── events.yaml        # our events, plus imports of upstream events
-    ├── spans.yaml         # the HTTP client span the fetch instrumentation records
+    ├── spans.yaml         # non-stable attributes the HTTP client instrumentations record
     └── common.yaml        # attributes the SDK adds to all telemetry it emits
 ```
 

--- a/semconv/README.md
+++ b/semconv/README.md
@@ -1,0 +1,60 @@
+# Federated Browser Semantic Conventions
+
+This directory holds the semantic conventions that the packages in this repository emit, modelled
+as a federated semantic convention registry ([OTEP 4815](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/4815-semantic-conventions-schema-v2.md)).
+The registry manifest declares the upstream
+[OpenTelemetry semantic conventions](https://github.com/open-telemetry/semantic-conventions) as an
+exact-version dependency, so our events can reference upstream attributes without redefining them.
+
+The same approach is used by
+[opentelemetry-android](https://github.com/open-telemetry/opentelemetry-android/tree/main/semconv).
+
+## Why these live here
+
+The semantic-conventions
+[CONTRIBUTING guide](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md)
+places conventions specific to a single runtime or a narrowly scoped implementation in the
+corresponding repository, and most of the conventions below are browser-only. Defining them here
+also gives a concrete starting point for the client-side registry proposed in
+[community#3594](https://github.com/open-telemetry/community/issues/3594).
+
+Names already covered upstream are deliberately not redefined. The `browser.web_vital` and
+`exception` events are imported from the dependency registry by name, and the `error.*`, `http.*`,
+`server.*`, `session.*`, and `url.*` attributes we emit are referenced from it.
+
+## Layout
+
+```text
+model/
+├── manifest.yaml          # registry identity and the upstream dependency
+└── browser/
+    ├── registry.yaml      # attributes defined by this repository
+    ├── events.yaml        # our events, plus imports of upstream events
+    ├── spans.yaml         # the HTTP client span the fetch instrumentation records
+    └── common.yaml        # attributes the SDK adds to all telemetry it emits
+```
+
+## Checking the registry
+
+Weaver is not required to install, build, or check the packages in this repository. To validate the
+model, run the [`weaver`](https://github.com/open-telemetry/weaver) CLI over `model/`:
+
+```bash
+docker run --rm -v "$PWD/semconv/model:/home/weaver/model" \
+  otel/weaver:v0.25.1 registry check -r /home/weaver/model
+```
+
+This resolves every `ref` against the pinned upstream version, so it catches unknown attribute
+references, malformed enum members, and duplicate ids.
+
+Do not pass `--future`: at the pinned upstream version it promotes the upstream registry's own
+`definition/2` file-format warnings to errors, which says nothing about this model.
+
+## Status
+
+The model currently describes what the instrumentations emit today, with no new conventions and no
+renames. Generating the TypeScript attribute and event-name constants from it, and enforcing the
+model in CI, are tracked in
+[#403](https://github.com/open-telemetry/opentelemetry-browser/issues/403). Until then the
+constants in the `semconv.ts` files under `packages/` remain hand-written, and changing an
+attribute means changing both.

--- a/semconv/model/browser/common.yaml
+++ b/semconv/model/browser/common.yaml
@@ -1,0 +1,12 @@
+groups:
+  - id: attributes.browser.session
+    type: attribute_group
+    stability: development
+    brief: >
+      Session attributes that the browser SDK adds to the telemetry it emits.
+    note: >
+      When session tracking is enabled, the SDK sets `session.id` on every span and log record it
+      produces, including the events defined in this registry.
+    attributes:
+      - ref: session.id
+        requirement_level: recommended

--- a/semconv/model/browser/events.yaml
+++ b/semconv/model/browser/events.yaml
@@ -1,0 +1,175 @@
+# Events defined in dependency registries are imported by name so that later code generation can
+# emit constants for them from this registry, rather than redefining them here.
+imports:
+  events:
+    - browser.web_vital
+    - exception
+
+groups:
+  - id: event.browser.console
+    type: event
+    name: browser.console
+    stability: development
+    brief: >
+      This event represents a message written to the browser console.
+    note: >
+      The body of the event is the serialized console arguments.
+    attributes:
+      - ref: browser.console.method
+        requirement_level: required
+
+  - id: event.browser.navigation
+    type: event
+    name: browser.navigation
+    stability: development
+    brief: >
+      This event represents a navigation to a page, either a full document load or a
+      same-document navigation performed by the application.
+    attributes:
+      - ref: url.full
+        requirement_level: required
+        brief: The URL navigated to.
+      - ref: browser.navigation.same_document
+        requirement_level: required
+      - ref: browser.navigation.hash_change
+        requirement_level: required
+      - ref: browser.navigation.type
+        requirement_level:
+          conditionally_required: >
+            If the type of the navigation can be determined. It is not reported for the initial
+            document load.
+
+  - id: event.browser.navigation_timing
+    type: event
+    name: browser.navigation_timing
+    stability: development
+    brief: >
+      This event represents the timing milestones the browser recorded while loading the current
+      document, as reported by the
+      [PerformanceNavigationTiming](https://developer.mozilla.org/docs/Web/API/PerformanceNavigationTiming)
+      API.
+    note: >
+      `PerformanceNavigationTiming` extends `PerformanceResourceTiming`, so this event reports the
+      inherited timings and transfer sizes using the same `browser.resource_timing.*` attributes as
+      the `browser.resource_timing` event.
+    attributes:
+      - ref: url.full
+        requirement_level: required
+        brief: The URL of the document.
+      - ref: browser.navigation_timing.type
+        requirement_level: required
+      - ref: browser.navigation_timing.dom_interactive
+        requirement_level: required
+      - ref: browser.navigation_timing.dom_content_loaded_event_start
+        requirement_level: required
+      - ref: browser.navigation_timing.dom_content_loaded_event_end
+        requirement_level: required
+      - ref: browser.navigation_timing.dom_complete
+        requirement_level: required
+      - ref: browser.navigation_timing.load_event_start
+        requirement_level: required
+      - ref: browser.navigation_timing.load_event_end
+        requirement_level: required
+      - ref: browser.navigation_timing.unload_event_start
+        requirement_level: required
+      - ref: browser.navigation_timing.unload_event_end
+        requirement_level: required
+      - ref: browser.navigation_timing.redirect_count
+        requirement_level: required
+      - ref: browser.resource_timing.duration
+        requirement_level: required
+      - ref: browser.resource_timing.fetch_start
+        requirement_level: required
+      - ref: browser.resource_timing.domain_lookup_start
+        requirement_level: required
+      - ref: browser.resource_timing.domain_lookup_end
+        requirement_level: required
+      - ref: browser.resource_timing.connect_start
+        requirement_level: required
+      - ref: browser.resource_timing.connect_end
+        requirement_level: required
+      - ref: browser.resource_timing.secure_connection_start
+        requirement_level: required
+      - ref: browser.resource_timing.request_start
+        requirement_level: required
+      - ref: browser.resource_timing.response_start
+        requirement_level: required
+      - ref: browser.resource_timing.response_end
+        requirement_level: required
+      - ref: browser.resource_timing.transfer_size
+        requirement_level: required
+      - ref: browser.resource_timing.encoded_body_size
+        requirement_level: required
+      - ref: browser.resource_timing.decoded_body_size
+        requirement_level: required
+
+  - id: event.browser.resource_timing
+    type: event
+    name: browser.resource_timing
+    stability: development
+    brief: >
+      This event represents the loading of a single resource by the page, as reported by the
+      [PerformanceResourceTiming](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming)
+      API.
+    attributes:
+      - ref: url.full
+        requirement_level: required
+        brief: The URL of the resource.
+      - ref: browser.resource_timing.initiator_type
+        requirement_level: required
+      - ref: browser.resource_timing.duration
+        requirement_level: required
+      - ref: browser.resource_timing.worker_start
+        requirement_level: required
+      - ref: browser.resource_timing.redirect_start
+        requirement_level: required
+      - ref: browser.resource_timing.redirect_end
+        requirement_level: required
+      - ref: browser.resource_timing.fetch_start
+        requirement_level: required
+      - ref: browser.resource_timing.domain_lookup_start
+        requirement_level: required
+      - ref: browser.resource_timing.domain_lookup_end
+        requirement_level: required
+      - ref: browser.resource_timing.connect_start
+        requirement_level: required
+      - ref: browser.resource_timing.connect_end
+        requirement_level: required
+      - ref: browser.resource_timing.secure_connection_start
+        requirement_level: required
+      - ref: browser.resource_timing.request_start
+        requirement_level: required
+      - ref: browser.resource_timing.response_start
+        requirement_level: required
+      - ref: browser.resource_timing.response_end
+        requirement_level: required
+      - ref: browser.resource_timing.transfer_size
+        requirement_level: required
+      - ref: browser.resource_timing.encoded_body_size
+        requirement_level: required
+      - ref: browser.resource_timing.decoded_body_size
+        requirement_level: required
+      - ref: browser.resource_timing.next_hop_protocol
+        requirement_level: recommended
+      - ref: browser.resource_timing.render_blocking_status
+        requirement_level: recommended
+
+  - id: event.browser.user_action.click
+    type: event
+    name: browser.user_action.click
+    stability: development
+    brief: >
+      This event represents a click by the user on an element of the page.
+    attributes:
+      - ref: browser.css_selector
+        requirement_level: required
+      - ref: browser.tag_name
+        requirement_level: required
+      - ref: browser.mouse_event.button
+        requirement_level: required
+      - ref: browser.page.x
+        requirement_level: required
+      - ref: browser.page.y
+        requirement_level: required
+      - ref: browser.element.attributes
+        requirement_level: required

--- a/semconv/model/browser/registry.yaml
+++ b/semconv/model/browser/registry.yaml
@@ -1,0 +1,422 @@
+groups:
+  - id: registry.browser.semconv
+    type: attribute_group
+    display_name: Browser Attributes
+    brief: >
+      Browser attributes emitted by the instrumentations in this repository that are not currently
+      defined by upstream OpenTelemetry semantic conventions.
+    stability: development
+    attributes:
+      # Console
+
+      - id: browser.console.method
+        type:
+          members:
+            - id: log
+              value: "log"
+              stability: development
+              brief: "`console.log` was called."
+            - id: info
+              value: "info"
+              stability: development
+              brief: "`console.info` was called."
+            - id: warn
+              value: "warn"
+              stability: development
+              brief: "`console.warn` was called."
+            - id: error
+              value: "error"
+              stability: development
+              brief: "`console.error` was called."
+            - id: debug
+              value: "debug"
+              stability: development
+              brief: "`console.debug` was called."
+        stability: development
+        brief: >
+          The console method that was called.
+        examples: ["error"]
+
+      # Navigation
+
+      - id: browser.navigation.same_document
+        type: boolean
+        stability: development
+        brief: >
+          Whether the navigation happened within the same document, without a full document load.
+        note: >
+          Soft navigations performed by a single-page application through the History or Navigation
+          API are same-document navigations; the initial page load is not.
+        examples: [true, false]
+
+      - id: browser.navigation.hash_change
+        type: boolean
+        stability: development
+        brief: >
+          Whether the navigation only changed the fragment of the URL.
+        examples: [true, false]
+
+      - id: browser.navigation.type
+        type:
+          members:
+            - id: push
+              value: "push"
+              stability: development
+              brief: A new entry was added to the history, e.g. by `history.pushState()`.
+            - id: replace
+              value: "replace"
+              stability: development
+              brief: The current history entry was replaced, e.g. by `history.replaceState()`.
+            - id: reload
+              value: "reload"
+              stability: development
+              brief: The current history entry was reloaded.
+            - id: traverse
+              value: "traverse"
+              stability: development
+              brief: An existing history entry was navigated to, e.g. by the back or forward button.
+        stability: development
+        brief: >
+          The type of the navigation, as reported by the
+          [Navigation API](https://developer.mozilla.org/docs/Web/API/NavigateEvent/navigationType).
+        examples: ["push"]
+
+      # Navigation timing
+      #
+      # Sourced from the
+      # [PerformanceNavigationTiming](https://developer.mozilla.org/docs/Web/API/PerformanceNavigationTiming)
+      # API. `PerformanceNavigationTiming` extends `PerformanceResourceTiming`, so the timings and
+      # transfer sizes it inherits are described by the `browser.resource_timing.*` attributes
+      # below rather than duplicated here.
+
+      - id: browser.navigation_timing.type
+        type:
+          members:
+            - id: navigate
+              value: "navigate"
+              stability: development
+              brief: Navigation started by clicking a link, entering a URL, a form submission, or a script operation.
+            - id: reload
+              value: "reload"
+              stability: development
+              brief: Navigation through a reload operation or a `Location.reload()` call.
+            - id: back_forward
+              value: "back_forward"
+              stability: development
+              brief: Navigation through the browser's history traversal, e.g. the back or forward button.
+            - id: prerender
+              value: "prerender"
+              stability: development
+              brief: Navigation to a page that was prerendered.
+        stability: development
+        brief: >
+          The type of the navigation, as reported by
+          [`PerformanceNavigationTiming.type`](https://developer.mozilla.org/docs/Web/API/PerformanceNavigationTiming/type).
+        examples: ["navigate"]
+
+      - id: browser.navigation_timing.dom_interactive
+        type: double
+        stability: development
+        brief: >
+          Time, in milliseconds relative to the start of the navigation, at which the parser
+          finished its work on the main document.
+        examples: [124.5]
+
+      - id: browser.navigation_timing.dom_content_loaded_event_start
+        type: double
+        stability: development
+        brief: >
+          Time, in milliseconds relative to the start of the navigation, immediately before the
+          `DOMContentLoaded` event handlers of the document start to run.
+        examples: [128.0]
+
+      - id: browser.navigation_timing.dom_content_loaded_event_end
+        type: double
+        stability: development
+        brief: >
+          Time, in milliseconds relative to the start of the navigation, immediately after the
+          `DOMContentLoaded` event handlers of the document finish running.
+        examples: [131.2]
+
+      - id: browser.navigation_timing.dom_complete
+        type: double
+        stability: development
+        brief: >
+          Time, in milliseconds relative to the start of the navigation, at which the document and
+          all of its subresources finished loading.
+        examples: [520.7]
+
+      - id: browser.navigation_timing.load_event_start
+        type: double
+        stability: development
+        brief: >
+          Time, in milliseconds relative to the start of the navigation, immediately before the
+          `load` event handlers of the document start to run.
+        examples: [521.0]
+
+      - id: browser.navigation_timing.load_event_end
+        type: double
+        stability: development
+        brief: >
+          Time, in milliseconds relative to the start of the navigation, immediately after the
+          `load` event handlers of the document finish running.
+        examples: [523.4]
+
+      - id: browser.navigation_timing.unload_event_start
+        type: double
+        stability: development
+        brief: >
+          Time, in milliseconds relative to the start of the navigation, immediately before the
+          `unload` event handlers of the previous document start to run.
+        note: >
+          Zero if there was no previous document, or if the previous document has a different
+          origin.
+        examples: [0.0]
+
+      - id: browser.navigation_timing.unload_event_end
+        type: double
+        stability: development
+        brief: >
+          Time, in milliseconds relative to the start of the navigation, immediately after the
+          `unload` event handlers of the previous document finish running.
+        note: >
+          Zero if there was no previous document, or if the previous document has a different
+          origin.
+        examples: [0.0]
+
+      - id: browser.navigation_timing.redirect_count
+        type: int
+        stability: development
+        brief: >
+          The number of redirects since the last non-redirect navigation in the current browsing
+          context.
+        examples: [0, 2]
+
+      # Resource timing
+      #
+      # Sourced from the
+      # [PerformanceResourceTiming](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming)
+      # API. Timings are milliseconds relative to the start of the navigation.
+
+      - id: browser.resource_timing.initiator_type
+        type: string
+        stability: development
+        brief: >
+          The type of the resource that initiated the performance entry, as reported by
+          [`PerformanceResourceTiming.initiatorType`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/initiatorType).
+        examples: ["script", "link", "img", "fetch", "xmlhttprequest"]
+
+      - id: browser.resource_timing.duration
+        type: double
+        stability: development
+        brief: >
+          The total time, in milliseconds, taken to fetch the resource.
+        examples: [42.3]
+
+      - id: browser.resource_timing.worker_start
+        type: double
+        stability: development
+        brief: >
+          Time immediately before the request is dispatched to a service worker.
+        note: >
+          Zero if the request is not intercepted by a service worker.
+        examples: [0.0, 12.1]
+
+      - id: browser.resource_timing.redirect_start
+        type: double
+        stability: development
+        brief: >
+          Time of the start of the fetch that initiated the first redirect.
+        note: >
+          Zero if there was no redirect, or if a redirect is not same-origin.
+        examples: [0.0]
+
+      - id: browser.resource_timing.redirect_end
+        type: double
+        stability: development
+        brief: >
+          Time immediately after receiving the last byte of the response of the last redirect.
+        note: >
+          Zero if there was no redirect, or if a redirect is not same-origin.
+        examples: [0.0]
+
+      - id: browser.resource_timing.fetch_start
+        type: double
+        stability: development
+        brief: >
+          Time immediately before the browser starts to fetch the resource.
+        examples: [1.2]
+
+      - id: browser.resource_timing.domain_lookup_start
+        type: double
+        stability: development
+        brief: >
+          Time immediately before the browser starts the domain name lookup for the resource.
+        examples: [1.4]
+
+      - id: browser.resource_timing.domain_lookup_end
+        type: double
+        stability: development
+        brief: >
+          Time immediately after the browser finishes the domain name lookup for the resource.
+        examples: [3.6]
+
+      - id: browser.resource_timing.connect_start
+        type: double
+        stability: development
+        brief: >
+          Time immediately before the browser starts to establish the connection to the server.
+        examples: [3.6]
+
+      - id: browser.resource_timing.connect_end
+        type: double
+        stability: development
+        brief: >
+          Time immediately after the browser finishes establishing the connection to the server.
+        examples: [12.8]
+
+      - id: browser.resource_timing.secure_connection_start
+        type: double
+        stability: development
+        brief: >
+          Time immediately before the browser starts the handshake process to secure the
+          connection.
+        note: >
+          Zero if the resource is not fetched over a secure connection.
+        examples: [6.0]
+
+      - id: browser.resource_timing.request_start
+        type: double
+        stability: development
+        brief: >
+          Time immediately before the browser starts requesting the resource from the server.
+        examples: [12.9]
+
+      - id: browser.resource_timing.response_start
+        type: double
+        stability: development
+        brief: >
+          Time immediately after the browser receives the first byte of the response.
+        examples: [38.1]
+
+      - id: browser.resource_timing.response_end
+        type: double
+        stability: development
+        brief: >
+          Time immediately after the browser receives the last byte of the resource, or immediately
+          before the transport connection is closed, whichever comes first.
+        examples: [43.5]
+
+      - id: browser.resource_timing.transfer_size
+        type: int
+        stability: development
+        brief: >
+          The size, in bytes, of the fetched resource, including the response header fields and the
+          response payload body.
+        examples: [4096]
+
+      - id: browser.resource_timing.encoded_body_size
+        type: int
+        stability: development
+        brief: >
+          The size, in bytes, of the payload body as received from the network, before removing any
+          applied content encoding.
+        examples: [3840]
+
+      - id: browser.resource_timing.decoded_body_size
+        type: int
+        stability: development
+        brief: >
+          The size, in bytes, of the message body after removing any applied content encoding.
+        examples: [10240]
+
+      - id: browser.resource_timing.next_hop_protocol
+        type: string
+        stability: development
+        brief: >
+          The network protocol used to fetch the resource, as identified by the
+          [ALPN Protocol ID](https://www.rfc-editor.org/rfc/rfc7301.html).
+        note: >
+          Empty for cross-origin resources that are not served with a `Timing-Allow-Origin`
+          response header field.
+        examples: ["http/1.1", "h2", "h3"]
+
+      - id: browser.resource_timing.render_blocking_status
+        type:
+          members:
+            - id: blocking
+              value: "blocking"
+              stability: development
+              brief: The resource blocked rendering.
+            - id: non_blocking
+              value: "non-blocking"
+              stability: development
+              brief: The resource did not block rendering.
+        stability: development
+        brief: >
+          The render-blocking status of the resource, as reported by
+          [`PerformanceResourceTiming.renderBlockingStatus`](https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/renderBlockingStatus).
+        examples: ["blocking"]
+
+      # User action
+
+      - id: browser.mouse_event.button
+        type:
+          members:
+            - id: left
+              value: "left"
+              stability: development
+              brief: The primary button, usually the left button.
+            - id: middle
+              value: "middle"
+              stability: development
+              brief: The auxiliary button, usually the mouse wheel button.
+            - id: right
+              value: "right"
+              stability: development
+              brief: The secondary button, usually the right button.
+        stability: development
+        brief: >
+          The mouse button that was pressed, as reported by
+          [`MouseEvent.button`](https://developer.mozilla.org/docs/Web/API/MouseEvent/button).
+        examples: ["left"]
+
+      - id: browser.page.x
+        type: double
+        stability: development
+        brief: >
+          The horizontal coordinate of the event relative to the whole document, in CSS pixels.
+        examples: [10.0, 131.5]
+
+      - id: browser.page.y
+        type: double
+        stability: development
+        brief: >
+          The vertical coordinate of the event relative to the whole document, in CSS pixels.
+        examples: [10.0, 99.5]
+
+      - id: browser.tag_name
+        type: string
+        stability: development
+        brief: >
+          The tag name of the element the event is relevant for, as reported by
+          [`Element.tagName`](https://developer.mozilla.org/docs/Web/API/Element/tagName).
+        examples: ["BUTTON", "A"]
+
+      - id: browser.css_selector
+        type: string
+        stability: development
+        brief: >
+          A CSS selector identifying the element the event is relevant for.
+        examples: ["#main > div:nth-child(2) > button.submit"]
+
+      - id: browser.element.attributes
+        type: any
+        stability: development
+        brief: >
+          Custom attributes read from the element the event is relevant for.
+        note: >
+          A map of string keys to string values, collected from the element's `data-otel-*`
+          attributes with the `data-otel-` prefix removed. For example, an element carrying
+          `data-otel-id="123"` contributes the entry `id` with the value `123`. The map is empty
+          when the element carries no such attributes.

--- a/semconv/model/browser/spans.yaml
+++ b/semconv/model/browser/spans.yaml
@@ -4,30 +4,17 @@ groups:
     span_kind: client
     stability: development
     brief: >
-      This span represents an outbound HTTP request made from the browser through `fetch`.
+      This span represents an outbound HTTP request made from the browser through `fetch` or
+      `XMLHttpRequest`.
     note: >
-      This group describes the subset of the upstream
+      The fetch and XHR instrumentations record the same attributes, so they share this group.
+      Both follow the upstream
       [HTTP client span](https://opentelemetry.io/docs/specs/semconv/http/http-spans/)
-      conventions that the fetch instrumentation records. It defines no attributes of its own; it
-      exists so that the upstream attributes the instrumentation uses are part of this registry.
+      conventions. The attributes they record from those conventions are stable, so the
+      instrumentations import their constants directly from
+      `@opentelemetry/semantic-conventions` and this registry does not restate them.
+      This group exists only to declare the attributes the instrumentations record that are
+      not yet stable upstream, and for which the package therefore exports no stable constant.
     attributes:
-      - ref: http.request.method
-        requirement_level: required
-      - ref: url.full
-        requirement_level: required
-      - ref: server.address
-        requirement_level: required
-      - ref: server.port
-        requirement_level:
-          conditionally_required: If the request URL carries a port.
-      - ref: http.request.method_original
-        requirement_level:
-          conditionally_required: If and only if it's different than `http.request.method`.
-      - ref: http.response.status_code
-        requirement_level:
-          conditionally_required: If and only if a response was received.
-      - ref: error.type
-        requirement_level:
-          conditionally_required: If the request failed or the response status code indicates an error.
       - ref: http.request.body.size
         requirement_level: opt_in

--- a/semconv/model/browser/spans.yaml
+++ b/semconv/model/browser/spans.yaml
@@ -1,0 +1,33 @@
+groups:
+  - id: span.browser.http.client
+    type: span
+    span_kind: client
+    stability: development
+    brief: >
+      This span represents an outbound HTTP request made from the browser through `fetch`.
+    note: >
+      This group describes the subset of the upstream
+      [HTTP client span](https://opentelemetry.io/docs/specs/semconv/http/http-spans/)
+      conventions that the fetch instrumentation records. It defines no attributes of its own; it
+      exists so that the upstream attributes the instrumentation uses are part of this registry.
+    attributes:
+      - ref: http.request.method
+        requirement_level: required
+      - ref: url.full
+        requirement_level: required
+      - ref: server.address
+        requirement_level: required
+      - ref: server.port
+        requirement_level:
+          conditionally_required: If the request URL carries a port.
+      - ref: http.request.method_original
+        requirement_level:
+          conditionally_required: If and only if it's different than `http.request.method`.
+      - ref: http.response.status_code
+        requirement_level:
+          conditionally_required: If and only if a response was received.
+      - ref: error.type
+        requirement_level:
+          conditionally_required: If the request failed or the response status code indicates an error.
+      - ref: http.request.body.size
+        requirement_level: opt_in

--- a/semconv/model/manifest.yaml
+++ b/semconv/model/manifest.yaml
@@ -1,0 +1,7 @@
+name: opentelemetry-browser
+description: Local semantic conventions for opentelemetry-browser.
+schema_url: https://opentelemetry.io/schemas/opentelemetry-browser/0.1.0
+dependencies:
+  - name: otel
+    registry_path: https://github.com/open-telemetry/semantic-conventions@v1.44.0[model]
+    schema_url: https://opentelemetry.io/schemas/1.44.0


### PR DESCRIPTION
This is the first part of #403 

This adds the semantic conventions this repo emits as a federated weaver registry under `semconv/` folder. The model describes what the instrumentations emit today.

Nothing is generated from the registry yet. Tooling, the generated constants, and CI enforcement will follow in separate PRs.

Validated with `weaver registry check` (see `semconv/README.md` for the command).

Disclosure: The yaml files were generated using an AI agent.