### PR TITLE
test(browser-instrumentation): fix flaky XHR span start time assertion

### DIFF
--- a/packages/instrumentation/src/xhr/instrumentation.test.ts
+++ b/packages/instrumentation/src/xhr/instrumentation.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { propagation, SpanKind, SpanStatusCode } from '@opentelemetry/api';
-import { hrTime, hrTimeToMilliseconds } from '@opentelemetry/core';
+import { hrTimeToMilliseconds, millisToHrTime } from '@opentelemetry/core';
 import { isWrapped } from '@opentelemetry/instrumentation';
 import {
   B3InjectEncoding,
@@ -375,7 +375,11 @@ describe('XhrInstrumentation', () => {
       const delay = 50;
       const url = getUrlForPath('/api/get');
       const xhr = new XMLHttpRequest();
-      const openTime = hrTime(performance.now());
+      // NOTE: read the same clock the SDK uses for the span start time
+      // (`Date.now()`, truncated to whole milliseconds). Mixing it with a
+      // `performance.now()` reading makes the delay check below flaky, since
+      // the two clocks can differ by up to a millisecond.
+      const openTime = millisToHrTime(Date.now());
       xhr.open('GET', url);
 
       // Simulate some work between open and send


### PR DESCRIPTION
The "should create spans when the request is sent" test compared two timestamps taken from different clocks: `openTime` came from `hrTime(performance.now())` (sub-millisecond precision), while `span.startTime` is stamped by the SDK from `Date.now()`, truncated to whole milliseconds.

That truncation discards up to 1ms, so an interval that genuinely exceeded the 50ms delay could measure below it. This failed four times in CI, always in the 49.6-50.0 band.

Read `openTime` from the same clock the SDK uses. With both endpoints truncated identically, floor(t + d) - floor(t) >= floor(d), so a real delay of at least 50ms can no longer read as less.