### PR TITLE
test: disable context and propagator globals on teardown

### DIFF
--- a/e2e-tests/utils/test-otel-setup.ts
+++ b/e2e-tests/utils/test-otel-setup.ts
@@ -1,4 +1,4 @@
-import { context, trace } from '@opentelemetry/api';
+import { context, propagation, trace } from '@opentelemetry/api';
 import { logs } from '@opentelemetry/api-logs';
 import { startBrowserSdk } from '@opentelemetry/browser-sdk';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
@@ -42,6 +42,7 @@ export function testSdkSetup(
       logs.disable();
       trace.disable();
       context.disable();
+      propagation.disable();
     },
   };
 }

--- a/packages/sdk/src/startBrowserSdk.test.ts
+++ b/packages/sdk/src/startBrowserSdk.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { diag, trace } from '@opentelemetry/api';
+import { context, diag, propagation, trace } from '@opentelemetry/api';
 import { logs } from '@opentelemetry/api-logs';
 import type { MockInstance } from 'vitest';
 import {
@@ -61,6 +61,8 @@ describe('startBrowserSdk', () => {
     fetchSpy.mockClear();
     logs.disable();
     trace.disable();
+    context.disable();
+    propagation.disable();
   });
 
   it('should not start disabled by configuration', async () => {
@@ -195,6 +197,8 @@ describe('quickStartBrowserSdk', () => {
     diagDebugSpy.mockRestore();
     logs.disable();
     trace.disable();
+    context.disable();
+    propagation.disable();
   });
 
   it('should not start when disabled by configuration', async () => {


### PR DESCRIPTION
## Which problem is this PR solving?

The test jobs print this error to stderr many times per run:

```
Error: @opentelemetry/api: Attempted duplicate registration of API: propagation
Error: @opentelemetry/api: Attempted duplicate registration of API: context
```

The tests still pass, but the noise makes CI logs harder to read. It happens on main too, so it is not new. A recent run on main had 27 of these lines.

## Short description of the changes

`startTracesSdk()` registers four globals: tracer provider, logger provider, context manager and propagator. Two test teardowns only disabled the logs and trace globals, so each following test registered a context manager and a propagator on top of a live one, and the API logged a duplicate registration error.

This adds the missing `disable()` calls in both places:

- `e2e-tests/utils/test-otel-setup.ts` now calls `propagation.disable()` next to the other three.
- `packages/sdk/src/startBrowserSdk.test.ts` now calls `context.disable()` and `propagation.disable()` in both `afterEach` blocks.

The SDK itself is not changed, because `shutdown()` is meant to flush the providers and leave the globals alone. The caller owns them, and here the callers are the tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `npm run test` passes: 9 files and 64 tests in the sdk package, 18 files and 315 tests in the instrumentation package.
- [x] `npm run test:e2e` passes: 5 files and 29 tests.

Note: the errors only show up in CI, not on my machine, so the clean log has to be confirmed by the CI run on this PR. The first commit already cut the count from 27 to 8, and the second commit targets the remaining 8.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
