### PR TITLE
test(instrumentation): restore spies in teardown instead of test bodies

### DIFF
--- a/packages/instrumentation/src/errors/instrumentation.test.ts
+++ b/packages/instrumentation/src/errors/instrumentation.test.ts
@@ -100,6 +100,7 @@ describe('ErrorsInstrumentation', () => {
     instrumentation?.disable();
     instrumentation = undefined;
     inMemoryExporter.reset();
+    vi.restoreAllMocks();
   });
 
   const getErrorLogs = () =>
@@ -144,8 +145,6 @@ describe('ErrorsInstrumentation', () => {
       );
       expect(errorCalls).toHaveLength(1);
       expect(rejectionCalls).toHaveLength(1);
-
-      addSpy.mockRestore();
     });
   });
 
@@ -203,8 +202,6 @@ describe('ErrorsInstrumentation', () => {
         'ignored error event with no error and no message',
         undefined,
       );
-
-      diagSpy.mockRestore();
     });
 
     it('should emit using event.message when event.error is missing', () => {
@@ -229,8 +226,6 @@ describe('ErrorsInstrumentation', () => {
         'ignored error event with no error and no message',
         undefined,
       );
-
-      diagSpy.mockRestore();
     });
 
     it('should prefer event.error over event.message when both are present', () => {
@@ -282,8 +277,6 @@ describe('ErrorsInstrumentation', () => {
         'ignored unhandledrejection event with no reason',
         null,
       );
-
-      diagSpy.mockRestore();
     });
 
     it('should not fall back to event.message for rejections even when one is present', () => {
@@ -300,8 +293,6 @@ describe('ErrorsInstrumentation', () => {
         'ignored unhandledrejection event with no reason',
         null,
       );
-
-      diagSpy.mockRestore();
     });
   });
 

--- a/packages/instrumentation/src/navigation-timing/instrumentation.test.ts
+++ b/packages/instrumentation/src/navigation-timing/instrumentation.test.ts
@@ -63,12 +63,13 @@ describe('NavigationTimingInstrumentation', () => {
   afterEach(() => {
     instrumentation.disable();
     inMemoryExporter.reset();
-    getEntriesByTypeSpy.mockRestore();
     document.body.innerHTML = '';
     restoreReadyState?.();
     restoreReadyState = undefined;
     restoreGetEntriesByType?.();
     restoreGetEntriesByType = undefined;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('should create an instance of NavigationTimingInstrumentation', () => {
@@ -292,7 +293,6 @@ describe('NavigationTimingInstrumentation', () => {
       vi.runOnlyPendingTimers();
     }
 
-    setTimeoutSpy.mockRestore();
     vi.useRealTimers();
   });
 
@@ -503,9 +503,6 @@ describe('NavigationTimingInstrumentation', () => {
       'pagehide',
       expect.any(Function),
     );
-
-    addEventListenerSpy.mockRestore();
-    removeEventListenerSpy.mockRestore();
   });
 
   it('should not subscribe multiple listeners when calling enable() consecutively', () => {
@@ -539,7 +536,5 @@ describe('NavigationTimingInstrumentation', () => {
       (call) => call[0] === 'load',
     );
     expect(loadCalls.length).toBe(1);
-
-    addEventListenerSpy.mockRestore();
   });
 });

--- a/packages/instrumentation/src/navigation/instrumentation.test.ts
+++ b/packages/instrumentation/src/navigation/instrumentation.test.ts
@@ -46,6 +46,7 @@ describe('NavigationInstrumentation', () => {
     inMemoryExporter.reset();
     restoreReadyState?.();
     restoreReadyState = undefined;
+    vi.restoreAllMocks();
   });
 
   const getNavigationLogs = () =>
@@ -95,8 +96,6 @@ describe('NavigationInstrumentation', () => {
         (c) => c[0] === 'popstate',
       );
       expect(popstateCalls).toHaveLength(1);
-
-      addSpy.mockRestore();
     });
   });
 

--- a/packages/instrumentation/src/web-vitals/instrumentation.test.ts
+++ b/packages/instrumentation/src/web-vitals/instrumentation.test.ts
@@ -45,6 +45,7 @@ describe('WebVitalsInstrumentation', () => {
     instrumentation?.disable();
     inMemoryExporter.reset();
     testContainer?.remove();
+    vi.restoreAllMocks();
   });
 
   const getWebVitalLogs = () =>
@@ -207,9 +208,7 @@ describe('WebVitalsInstrumentation', () => {
 
   describe('applyCustomLogRecordData hook', () => {
     it('should catch and log errors from hook without crashing', async () => {
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
       const errorHook = vi.fn(() => {
         throw new Error('Hook error');
       });
@@ -224,8 +223,6 @@ describe('WebVitalsInstrumentation', () => {
       const inpLog = await waitForMetric('inp');
       expect(inpLog.attributes[ATTR_WEB_VITAL_NAME]).toBe('inp');
       expect(errorHook).toHaveBeenCalled();
-
-      consoleErrorSpy.mockRestore();
     });
 
     it('should allow hook to add custom attributes', async () => {


### PR DESCRIPTION
## Which problem is this PR solving?

Part of the vitest upgrade work.

Several instrumentation tests called `mockRestore()` at the end of the test body. If an assertion failed before that line, the spy stayed in place and leaked into later tests in the same file. The navigation timing tests also left fake timers active when a test failed early.

## Short description of the changes

Move spy cleanup into `afterEach` with `vi.restoreAllMocks()` and drop the per test `mockRestore()` calls. The navigation timing suite also calls `vi.useRealTimers()` in teardown.

Follow up to #422, which did the same for the SDK and e2e teardown.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `npm test`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
