### PR TITLE
docs(sdk): correct config option docs

### DIFF
--- a/packages/sdk/src/core/sdk.ts
+++ b/packages/sdk/src/core/sdk.ts
@@ -21,7 +21,7 @@ interface SdkFactories {
 }
 
 /**
- * Utility functions to extract the configurations from the factory
+ * Utility types to extract the configurations from the factory
  * functions and remove the common properties (which will be already
  * available at the config root)
  */
@@ -40,8 +40,8 @@ const DEFAULT_CONFIG: RootConfig = {
 const NOOP_SDK = { shutdown: () => Promise.resolve() };
 
 /**
- * Combines different SDK factory functions into a single one
- * which accepts a global configuration along
+ * Combines different SDK factory functions into a single one which accepts a
+ * root configuration shared by every signal
  */
 export function combineSdks<T extends SdkFactories>(
   factories: T,
@@ -99,9 +99,8 @@ export function combineSdks<T extends SdkFactories>(
       const logsConfig = (config?.logs || {}) as LogsConfig;
       const isGenericEndpoint = !logsConfig.exportConfig?.url;
 
-      // Propagate root configs to signal configs only when the signal does not
-      // have custom processors. When processors are provided, exportConfig and
-      // batchProcessorConfig are intentionally ignored per the LogsConfig docs.
+      // Propagate root configs only when the signal has no custom processors.
+      // A signal `exportConfig` still adds a batch OTLP processor, see `LogsConfig`.
       if (!logsConfig.processors) {
         if (!logsConfig.batchProcessorConfig) {
           logsConfig.batchProcessorConfig =
@@ -126,9 +125,8 @@ export function combineSdks<T extends SdkFactories>(
       const tracesConfig = (config?.traces || {}) as TracesConfig;
       const isGenericEndpoint = !tracesConfig.exportConfig?.url;
 
-      // Propagate root configs to signal configs only when the signal does not
-      // have custom processors. When processors are provided, exportConfig and
-      // batchProcessorConfig are intentionally ignored per the TracesConfig docs.
+      // Propagate root configs only when the signal has no custom processors.
+      // A signal `exportConfig` still adds a batch OTLP processor, see `TracesConfig`.
       if (!tracesConfig.processors) {
         if (!tracesConfig.batchProcessorConfig) {
           tracesConfig.batchProcessorConfig =

--- a/packages/sdk/src/core/types.ts
+++ b/packages/sdk/src/core/types.ts
@@ -24,9 +24,10 @@ import type {
  */
 export interface ExportConfig {
   /**
-   * URL to send the data. For signal specific exports you might need to
-   * specify the signal path like `/v1/traces`. Default values depend on where
-   * this config is defined:
+   * URL to send the data. A URL set in a signal config is used as is, so it
+   * must include the signal path. When a signal `exportConfig` has no `url`
+   * the root URL is used with the signal path set on it. Default values
+   * depend on where this config is defined:
    * - globally: the default is http://localhost:4318
    * - logs: the default is http://localhost:4318/v1/logs
    * - traces: the default is http://localhost:4318/v1/traces
@@ -72,10 +73,10 @@ export interface BatchProcessorConfig {
 }
 
 /**
- * The common configuration properties regardles of the SDK being
+ * The common configuration properties regardless of the SDK being
  * started. Any signal SDK should accept it and when SDKs are combined
  * these properties belong to the root configuration and not to
- * the sginal specific config.
+ * the signal specific config.
  */
 export interface CommonConfig {
   /**
@@ -120,14 +121,16 @@ export interface CommonConfig {
 export type RootConfig = CommonConfig & {
   /**
    * Configuration for processors. If defined it will be applied to
-   * `BatchSpanProcessor` and `BatchLogRecordProcessor` unless signal
-   * specific configuration is set for the signal.
+   * `BatchSpanProcessor` and `BatchLogRecordProcessor` unless the signal sets
+   * its own `batchProcessorConfig` or `processors`.
    */
   batchProcessorConfig?: BatchProcessorConfig;
   /**
    * Configuration for exporters. If defined it will be applied to the
-   * exporters of the `BatchSpanProcessor` and `BatchLogRecordProcessor`
-   * unless signal specific configuration is set for the signal.
+   * exporters of the `BatchSpanProcessor` and `BatchLogRecordProcessor` unless
+   * the signal sets its own `exportConfig` or `processors`. The URL is the
+   * exception: it is used, with the signal path set on it, whenever the signal
+   * `exportConfig` has no `url` of its own.
    */
   exportConfig?: ExportConfig;
   // TODO: to be discussed in Browser SIG
@@ -140,11 +143,14 @@ export type RootConfig = CommonConfig & {
 
 export type LogsConfig = CommonConfig & {
   /**
-   * Configuration for the LogRecord processor.
+   * Configuration for the `BatchLogRecordProcessor`, used whenever one is
+   * created for this signal.
    */
   batchProcessorConfig?: BatchProcessorConfig;
   /**
-   * Configuration for the LogRecord exporter.
+   * Configuration for the LogRecord exporter. Setting this config creates a
+   * `BatchLogRecordProcessor`, with the defaults for batch and queue size and
+   * export schedule and timeouts unless `batchProcessorConfig` is set.
    */
   exportConfig?: ExportConfig;
   /**
@@ -152,9 +158,11 @@ export type LogsConfig = CommonConfig & {
    */
   logRecordLimits?: LogRecordLimits;
   /**
-   * List of LogRecordProcessor for the logger provider. Setting this will make the SDK
-   * ignore `batchProcessorConfig` and `exportConfig` since no `BatchLogRecordProcessor` will
-   * be created.
+   * List of LogRecordProcessor for the logger provider. Setting this stops the root
+   * `batchProcessorConfig` and `exportConfig` from being propagated to this signal
+   * when SDKs are combined. Without a signal `exportConfig` the SDK adds no
+   * `BatchLogRecordProcessor` of its own. With one, it adds a
+   * `BatchLogRecordProcessor` next to the processors listed.
    */
   processors?: LogRecordProcessor[];
 };
@@ -162,7 +170,7 @@ export type LogsConfig = CommonConfig & {
 export type TracesConfig = CommonConfig & {
   // Context and Propagation
   /**
-   * Manager use to carry context accross function boundaries
+   * Manager used to carry context across function boundaries
    *
    * @defaultValue undefined
    */
@@ -175,23 +183,21 @@ export type TracesConfig = CommonConfig & {
    */
   propagators?: TextMapPropagator[];
   /**
-   * Sampler to be used by tracer to decide if a Span os sampled or not.
+   * Sampler to be used by tracer to decide if a Span is sampled or not.
    *
    * @defaultValue undefined
    */
   sampler?: Sampler;
   /**
-   * Configuration for the Span processor. Setting this
-   * config will enable a `BatchSpanProcessor` whith an exporter
-   * that has the default configuration or the one set in `exportConfig`
-   * option.
+   * Configuration for the `BatchSpanProcessor`, used whenever one is created for
+   * this signal. Its exporter takes the default configuration or the one set in
+   * the `exportConfig` option.
    */
   batchProcessorConfig?: BatchProcessorConfig;
   /**
-   * Configuration for the Span exporter. Setting this
-   * config will enable a `BatchSpanProcessor` whith the default
-   * options for batch and queue size and export schedule and timeouts
-   * unless the `batchProcessorConfig` option is set.
+   * Configuration for the Span exporter. Setting this config creates a
+   * `BatchSpanProcessor`, with the defaults for batch and queue size and export
+   * schedule and timeouts unless the `batchProcessorConfig` option is set.
    */
   exportConfig?: ExportConfig;
   /**
@@ -199,9 +205,11 @@ export type TracesConfig = CommonConfig & {
    */
   spanLimits?: SpanLimits;
   /**
-   * List of SpanProcessor for the tracer provider. Setting this will make the SDK
-   * ignore `processorConfig` and `exportConfig` since no `BatchSpanProcessor` will
-   * be created.
+   * List of SpanProcessor for the tracer provider. Setting this stops the root
+   * `batchProcessorConfig` and `exportConfig` from being propagated to this signal
+   * when SDKs are combined. Without a signal `exportConfig` the SDK adds no
+   * `BatchSpanProcessor` of its own. With one, it adds a `BatchSpanProcessor`
+   * next to the processors listed.
    *
    * @defaultValue undefined
    */

--- a/packages/sdk/src/startBrowserSdk.test.ts
+++ b/packages/sdk/src/startBrowserSdk.test.ts
@@ -50,12 +50,11 @@ describe('startBrowserSdk', () => {
   const diagDebugSpy = vi.spyOn(diag, 'debug');
   let browserSdk: WebSdk;
 
-  // NOTE: we mock the registration of the logger/tracer provider because
-  // the APIs only allow to register once. With the mock we can use
-  // a dedicated provider for the test
   afterAll(() => {
     fetchSpy.mockRestore();
   });
+  // NOTE: the logs and trace APIs only accept one provider registration, so
+  // they are disabled after each test to let the next one register its own
   afterEach(async () => {
     await browserSdk?.shutdown();
     fetchSpy.mockClear();

--- a/packages/sdk/src/startBrowserSdk.ts
+++ b/packages/sdk/src/startBrowserSdk.ts
@@ -17,7 +17,7 @@ import { startLogsSdk } from './logs/startLogsSdk.ts';
 import { startTracesSdk } from './traces/startTracesSdk.ts';
 
 /**
- * Combination of all singal SDKs into one. A shorthand for users to
+ * Combination of all signal SDKs into one. A shorthand for users to
  * start with all signals allowing them to pass some global configuration
  * options.
  */
@@ -50,7 +50,8 @@ export interface QuickStartConfig {
    */
   serviceVersion?: string;
   /**
-   * Target URL for the SDK to send traces and logs.
+   * Target URL for the SDK to send traces and logs. The signal path (`/v1/logs`,
+   * `/v1/traces`) is set on it for each signal, replacing any path given here.
    */
   exportUrl: string;
   /**


### PR DESCRIPTION
## Which problem is this PR solving?

Several JSDoc comments on the SDK config types describe the opposite of what the code does. `LogsConfig.processors` and `TracesConfig.processors` say that setting them makes the SDK ignore `exportConfig`, but `startLogsSdk` and `startTracesSdk` still create a batch processor when the signal sets its own `exportConfig`. `TracesConfig.batchProcessorConfig` claims to enable a `BatchSpanProcessor` on its own, which it does not.

These comments are what make the propagation rules easy to get wrong, so they are worth correcting on their own.

## Short description of the changes

Comments only. No behavior changes, and no test changes other than one comment.

The `processors`, `exportConfig` and `batchProcessorConfig` docs on `RootConfig`, `LogsConfig` and `TracesConfig` now match the signal SDKs. `ExportConfig.url` says that a URL set on a signal is used as is, while a signal `exportConfig` with no `url` gets the root URL with the signal path set on it. `QuickStartConfig.exportUrl` says the signal path replaces any path given.

The `combineSdks` doc had an unfinished sentence. A test note said the suite mocks provider registration, which it does not, and it now describes what the hook actually does.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] `npm test` passes repo wide, `packages/sdk` at 64/64, unchanged from `main` since no behavior changed.
- [x] `npm run check` is clean.
- [x] Each corrected comment was read against the code it describes in `combineSdks`, `startLogsSdk` and `startTracesSdk`.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [x] Documentation has been updated
